### PR TITLE
feat: Update proto version and grpc utils

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -160,7 +160,7 @@ dependencies {
 	//	ADempiere gRPC Utils Base (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-grpc-utils)
 	implementation "${baseGroupId}:adempiere-grpc-utils:1.3.9"
 	// AWS3 Connector to use as File Storagee (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-s3-connector)
-	implementation "io.github.adempiere:adempiere-s3-connector:1.0.1"
+	implementation "${baseGroupId}:adempiere-s3-connector:1.0.1"
 
 	//	Others
 	compileOnly 'org.apache.tomcat:annotations-api:6.0.53'

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ group 'com.nikhilm'
 sourceCompatibility = 1.11
 
 def grpcVersion = '1.62.2'
+def protobufVersion = '3.25.3'
 def baseVersion = '3.9.4'
 def baseGroupId = 'io.github.adempiere'
 def privateDependencyBaseVersion = "adempiere-3.9.4"
@@ -48,11 +49,11 @@ repositories {
 
 protobuf {
 	protoc {
-		artifact = "com.google.protobuf:protoc:3.25.3"
+		artifact = "com.google.protobuf:protoc:${protobufVersion}"
 	}
 	plugins {
 		grpc {
-			artifact = 'io.grpc:protoc-gen-grpc-java:1.34.1'
+			artifact = "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
 		}
 	}
 	generateProtoTasks {
@@ -72,7 +73,7 @@ protobuf {
 			// If true, the descriptor set will contain line number information
 			// and comments. Default is false.
 			task.descriptorSetOptions.includeSourceInfo = true
-		
+
 			// If true, the descriptor set will contain all transitive imports and
 			// is therefore self-contained. Default is false.
 			task.descriptorSetOptions.includeImports = true
@@ -146,20 +147,23 @@ dependencies {
     implementation "io.grpc:grpc-stub:${grpcVersion}"
     implementation "io.grpc:grpc-netty:${grpcVersion}"
     // https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java
-	implementation 'com.google.protobuf:protobuf-java:3.25.3'
-	implementation 'com.google.protobuf:protobuf-java-util:3.25.3'
+	implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
+	implementation "com.google.protobuf:protobuf-java-util:${protobufVersion}"
 
-    //implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
-	//implementation 'com.sun.xml.bind:jaxb-impl:3.0.0-M4'
-	//implementation 'com.sun.xml.bind:jaxb-core:3.0.0-M4'
-	//implementation 'javax.activation:activation:1.1.1'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.0'
+	// ADempiere External Libraries
 	implementation 'io.vavr:vavr:0.10.4'
+
 	//	ADempiere Core
 	implementation "${baseGroupId}:base:${baseVersion}"
+
+	// ADempiere Projects with additional features
+	//	ADempiere gRPC Utils Base (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-grpc-utils)
 	implementation "${baseGroupId}:adempiere-grpc-utils:1.3.9"
-	implementation "org.apache.poi:poi-ooxml:5.2.5"
+	// AWS3 Connector to use as File Storagee (https://central.sonatype.com/artifact/io.github.adempiere/adempiere-s3-connector)
 	implementation "io.github.adempiere:adempiere-s3-connector:1.0.1"
+
 	//	Others
-    compileOnly 'org.apache.tomcat:annotations-api:6.0.53'
+	compileOnly 'org.apache.tomcat:annotations-api:6.0.53'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.0'
+	implementation "org.apache.poi:poi-ooxml:5.2.5"
 }


### PR DESCRIPTION
- com.google.protobuf:protobuf-java to `3.25.3`.
- com.google.protobuf:protobuf-java-util to `3.25.3`.
- io.github.adempiere:adempiere-s3-connector to `1.0.2`.