### PR TITLE
fix: NPE when response zero rows.

### DIFF
--- a/src/main/java/org/spin/report_engine/data/ReportInfo.java
+++ b/src/main/java/org/spin/report_engine/data/ReportInfo.java
@@ -217,8 +217,9 @@ public class ReportInfo {
 		Map<Integer, Integer> columnLength = new HashMap<>();
 		groupedRows = summaryHandler.getAsRows();
 		List<Row> completeRows = Stream.concat(getRows().stream(), groupedRows.stream())
-				.sorted(getSortingValue(false))
-                .collect(Collectors.toList());
+			.sorted(getSortingValue(false))
+			.collect(Collectors.toList())
+		;
 		Language language = Language.getLoginLanguage();
 		rows = new ArrayList<Row>();
 		summaryRows = new ArrayList<Row>();
@@ -252,7 +253,17 @@ public class ReportInfo {
 				summaryRows.add(newRow);
 			}
 		});
-		columns = columns.stream().map(column -> column.withColumnCharactersSize(columnLength.get(column.getPrintFormatItemId()))).collect(Collectors.toList());
+
+		if (columnLength == null || columnLength.isEmpty()) {
+			return this;
+		}
+		columns = columns.stream()
+			.map(column -> {
+				Integer columnCharactersSizeId = columnLength.get(column.getPrintFormatItemId());
+				return column.withColumnCharactersSize(columnCharactersSizeId);
+			})
+			.collect(Collectors.toList())
+		;
 		return this;
 	}
 	


### PR DESCRIPTION
#### Request
```bash
curl --location --globoff --request GET 'http://192.168.3.53/api/report-engine/reports/145?report_type=pdf&filters=[{%22name%22%3A%22DaysDue%22%2C%22operator%22%3A%22between%22%2C%22values%22%3A-99999}%2C{%22name%22%3A%22DaysDue_To%22%2C%22operator%22%3A%22less_equal%22%2C%22values%22%3A99999}]&page_size=15&page_token=1&is_summary=true' \
--header 'Accept: application/json, text/plain, */*' \
--header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIyMDE1NzQ4IiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjEwMDAwMDMsIkFEX1JvbGVfSUQiOjEwMDAwMDIsIkFEX1VzZXJfSUQiOjIwMDAwMjQsIk1fV2FyZWhvdXNlX0lEIjotMSwiQURfTGFuZ3VhZ2UiOiJlbl9VUyIsImlhdCI6MTcyNjEzODYyMCwiZXhwIjoxNzI2MjI1MDIwfQ.h0RfHtVrar5PHmzxHPcOU_59wQa199Om5poPiCI2VAk' \
--header 'Origin: http://0.0.0.0:9527' \
--header 'Connection: keep-alive' \
--header 'Referer: http://0.0.0.0:9527/' \
--header 'Priority: u=0'
```

#### Response
```json
{
    "code": 13,
    "message": "",
    "details": []
}
```
Log server
```log
===========> ReportService.getReport: null [24]
java.lang.NullPointerException
        at org.spin.report_engine.data.ReportInfo.lambda$15(ReportInfo.java:255)
        at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)
        at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
        at org.spin.report_engine.data.ReportInfo.completeInfo(ReportInfo.java:255)
        at org.spin.report_engine.service.ReportBuilder.get(ReportBuilder.java:230)
        at org.spin.report_engine.service.ReportBuilder.lambda$5(ReportBuilder.java:251)
        at org.compiere.util.Trx.run(Trx.java:529)
        at org.compiere.util.Trx.run(Trx.java:497)
        at org.spin.report_engine.service.ReportBuilder.run(ReportBuilder.java:246)
        at org.spin.report_engine.service.Service.getReport(Service.java:161)
        at org.spin.report_engine.controller.ReportService.getReport(ReportService.java:36)
        at org.spin.backend.grpc.report_engine.ReportEngineGrpc$MethodHandlers.invoke(ReportEngineGrpc.java:368)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:356)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```