### PR TITLE
fix: Pre-Release replace docker `latest` and `alpine` tags.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_deployUsername: ${{ secrets.DEPLOY_USER }}
           ORG_GRADLE_PROJECT_deployToken: ${{ secrets.DEPLOY_TOKEN }}
-          ORG_GRADLE_PROJECT_deplyRepository: ${{ secrets.DEPLOY_REPOSITORY }}
+          ORG_GRADLE_PROJECT_deployRepository: ${{ secrets.DEPLOY_REPOSITORY }}
           GITHUB_DEPLOY_USER: ${{ github.actor }}
           GITHUB_DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_DEPLOY_REPOSITORY: ${{ secrets.DEPLOY_REPOSITORY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -143,7 +143,6 @@ jobs:
         with:
           name: release-artifacts
           path: artifacts/
-          pattern: adempiere-report-engine-service.zip
 
       - name: Unzip Asset
         run: |
@@ -197,7 +196,6 @@ jobs:
         with:
           name: release-artifacts
           path: artifacts/
-          pattern: adempiere-report-engine-service.zip
 
       - name: Unzip Asset
         run: |
@@ -282,7 +280,6 @@ jobs:
         with:
           name: release-artifacts
           path: artifacts/
-          pattern: adempiere-report-engine-service.dsc
 
       - name: Move descriptor
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,100 +48,54 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_deployUsername: ${{ secrets.DEPLOY_USER }}
           ORG_GRADLE_PROJECT_deployToken: ${{ secrets.DEPLOY_TOKEN }}
-          ORG_GRADLE_PROJECT_deplyRepository: ${{ secrets.DEPLOY_REPOSITORY }}
+          ORG_GRADLE_PROJECT_deployRepository: ${{ secrets.DEPLOY_REPOSITORY }}
           GITHUB_DEPLOY_USER: ${{ github.actor }}
           GITHUB_DEPLOY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_DEPLOY_REPOSITORY: ${{ secrets.DEPLOY_REPOSITORY }}
 
-      - name: Upload descriptor file artifact
+      - name: Prepare flat artifacts
+        run: |
+          mkdir -p flat_artifacts/
+          cp build/descriptors/adempiere-report-engine-service.dsc flat_artifacts/ || echo "Warning: .dsc file not found"
+          cp build/release/adempiere-report-engine-service.* flat_artifacts/ || echo "Warning: release files not found"
+          cp docker-compose/envoy/envoy.yaml flat_artifacts/ || echo "Warning: envoy.yaml not found"
+          cp resources/env.yaml flat_artifacts/ || echo "Warning: env.yaml not found"
+          ls -la flat_artifacts/
+
+      - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: adempiere-report-engine-service.dsc
-          path: build/descriptors/adempiere-report-engine-service.dsc
+          name: release-artifacts
+          path: flat_artifacts/*
           retention-days: 1
 
-      - name: Upload envoy file artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: envoy.yaml
-          path: docker-compose/envoy/envoy.yaml
 
-      - name: Upload dist app zip artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: adempiere-report-engine-service.zip
-          path: build/release/adempiere-report-engine-service.zip
-
-      - name: Upload dist app zip.MD5 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: adempiere-report-engine-service.zip.MD5
-          path: build/release/adempiere-report-engine-service.zip.MD5
-
-      - name: Upload dist app tar artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: adempiere-report-engine-service.tar
-          path: build/release/adempiere-report-engine-service.tar
-
-      - name: Upload dist app tar.MD5 artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: adempiere-report-engine-service.tar.MD5
-          path: build/release/adempiere-report-engine-service.tar.MD5
 
   publish-binaries:
-    name: Upload Binaries adempiere-report-engine-service
+    name: Publish Release Assets
     needs: build-app
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - name: Download all artifacts
+      - name: Download artifacts
         uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: artifacts/
 
-      - name: Upload Descriptor
-        uses: skx/github-action-publish-binaries@master
+      - name: Upload to GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.event.release.tag_name }}
+          files: |
+            artifacts/adempiere-report-engine-service.dsc
+            artifacts/adempiere-report-engine-service.zip
+            artifacts/adempiere-report-engine-service.zip.MD5
+            artifacts/adempiere-report-engine-service.tar
+            artifacts/adempiere-report-engine-service.tar.MD5
+            artifacts/envoy.yaml
+            artifacts/env.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: adempiere-report-engine-service.dsc/adempiere-report-engine-service.dsc
-
-      - name: Upload Envoy config
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: envoy.yaml/envoy.yaml
-
-      - name: Upload zip
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: adempiere-report-engine-service.zip/adempiere-report-engine-service.zip
-
-      - name: Upload zip.MD5
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: adempiere-report-engine-service.zip.MD5/adempiere-report-engine-service.zip.MD5
-
-      - name: Upload tar
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: adempiere-report-engine-service.tar/adempiere-report-engine-service.tar
-
-      - name: Upload tar.MD5
-        uses: skx/github-action-publish-binaries@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          args: adempiere-report-engine-service.tar.MD5/adempiere-report-engine-service.tar.MD5
 
 
 
@@ -179,19 +133,38 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - name: Download build dist app
+
+      - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
-          name: adempiere-report-engine-service.zip
+          name: release-artifacts
+          path: artifacts/
+          pattern: adempiere-report-engine-service.zip
+
       - name: Unzip Asset
         run: |
-          unzip adempiere-report-engine-service.zip -d docker/
-      - name: Login to GitHub Container Registry
+          unzip artifacts/adempiere-report-engine-service.zip -d docker/
+
+      - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
           # CONFIGURE DOCKER SECRETS INTO REPOSITORY
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Set Docker Alpine Tags
+        id: set_tags_alpine
+        run: |
+          # Get the release type
+          IS_PRE_RELEASE=${{ github.event.release.prerelease }}
+          # Set the base tags, always include the specific version tag
+          TAGS="${{ secrets.DOCKER_HUB_REPO_NAME }}:${{ github.event.release.tag_name }}-alpine"
+          # If it's not a pre-release, add the "latest" tag
+          if [[ "$IS_PRE_RELEASE" == "false" ]]; then
+            TAGS+=",${{ secrets.DOCKER_HUB_REPO_NAME }}:alpine"
+          fi
+          # Set the output variable for the next step to use
+          echo "tags_to_push=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Push alpine image in Docker Hub
         uses: docker/build-push-action@v6
@@ -199,9 +172,7 @@ jobs:
           context: .
           file: docker/alpine.Dockerfile
           push: true
-          tags: |
-            ${{ secrets.DOCKER_HUB_REPO_NAME }}:alpine-${{ github.event.release.tag_name }}
-            ${{ secrets.DOCKER_HUB_REPO_NAME }}:alpine
+          tags: ${{ steps.set_tags_alpine.outputs.tags_to_push }}
 
   # TODO: Download .tar and add docker image without uncompress
   # Publish docker multiplatform image in Docker Hub Registry to application
@@ -215,36 +186,53 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      - name: Download build dist app
+
+      - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
-          name: adempiere-report-engine-service.zip
+          name: release-artifacts
+          path: artifacts/
+          pattern: adempiere-report-engine-service.zip
+
       - name: Unzip Asset
         run: |
-          unzip adempiere-report-engine-service.zip -d docker/
-      - name: Set up QEMU
+          unzip artifacts/adempiere-report-engine-service.zip -d docker/
+
+      - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
+      - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
           # CONFIGURE DOCKER SECRETS INTO REPOSITORY
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
-      - name: Push image in Docker Hub
+      - name: Set Docker Tags
+        id: set_tags
+        run: |
+          # Get the release type
+          IS_PRE_RELEASE=${{ github.event.release.prerelease }}
+          # Set the base tags, always include the specific version tag
+          TAGS="${{ secrets.DOCKER_HUB_REPO_NAME }}:${{ github.event.release.tag_name }}"
+          # If it's not a pre-release, add the "latest" tag
+          if [[ "$IS_PRE_RELEASE" == "false" ]]; then
+            TAGS+=",${{ secrets.DOCKER_HUB_REPO_NAME }}:latest"
+          fi
+          # Set the output variable for the next step to use
+          echo "tags_to_push=$TAGS" >> $GITHUB_OUTPUT
+
+      - name: Push ubuntu image in Docker Hub
         uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/ubuntu.Dockerfile
           platforms: linux/amd64,linux/amd64/v2,linux/arm64/v8
           push: true
-          tags: |
-            ${{ secrets.DOCKER_HUB_REPO_NAME }}:${{ github.event.release.tag_name }}
-            ${{ secrets.DOCKER_HUB_REPO_NAME }}:latest
+          tags: ${{ steps.set_tags.outputs.tags_to_push }}
 
 
 
@@ -283,24 +271,44 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Download descriptor app
+      - name: Download dist artifacts
         uses: actions/download-artifact@v4
         with:
-          name: adempiere-report-engine-service.dsc
-          path: docker/
+          name: release-artifacts
+          path: artifacts/
+          pattern: adempiere-report-engine-service.dsc
 
-      - name: Set up QEMU
+      - name: Move descriptor
+        run: |
+          tree -d
+          cp artifacts/adempiere-report-engine-service.dsc docker/ || echo "Warning: descriptor file not found"
+
+      - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
 
-      - name: Set up Docker Buildx
+      - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Login to Container Registry
         uses: docker/login-action@v3
         with:
           # CONFIGURE DOCKER SECRETS INTO REPOSITORY
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Set Docker Tags
+        id: set_proxy_tags
+        run: |
+          # Get the release type
+          IS_PRE_RELEASE=${{ github.event.release.prerelease }}
+          # Set the base tags, always include the specific version tag
+          TAGS="${{ secrets.DOCKER_HUB_PROXY_REPO_NAME }}:${{ github.event.release.tag_name }}"
+          # If it's not a pre-release, add the "latest" tag
+          if [[ "$IS_PRE_RELEASE" == "false" ]]; then
+            TAGS+=",${{ secrets.DOCKER_HUB_PROXY_REPO_NAME }}:latest"
+          fi
+          # Set the output variable for the next step to use
+          echo "tags_to_push=$TAGS" >> $GITHUB_OUTPUT
 
       - name: Push image in Docker Hub
         uses: docker/build-push-action@v6
@@ -309,6 +317,4 @@ jobs:
           file: docker/proxy.Dockerfile
           platforms: linux/amd64,linux/amd64/v2,linux/arm64/v8
           push: true
-          tags: |
-            ${{ secrets.DOCKER_HUB_PROXY_REPO_NAME }}:${{ github.event.release.tag_name }}
-            ${{ secrets.DOCKER_HUB_PROXY_REPO_NAME }}:latest
+          tags: ${{ steps.set_proxy_tags.outputs.tags_to_push }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,6 +82,10 @@ jobs:
           name: release-artifacts
           path: artifacts/
 
+      - name: List Assets
+        run: |
+          tree artifacts
+
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@v1
         with:
@@ -143,6 +147,7 @@ jobs:
 
       - name: Unzip Asset
         run: |
+          tree artifacts
           unzip artifacts/adempiere-report-engine-service.zip -d docker/
 
       - name: Login to Container Registry
@@ -196,6 +201,7 @@ jobs:
 
       - name: Unzip Asset
         run: |
+          tree artifacts
           unzip artifacts/adempiere-report-engine-service.zip -d docker/
 
       - name: Setup QEMU
@@ -280,7 +286,7 @@ jobs:
 
       - name: Move descriptor
         run: |
-          tree -d
+          tree artifacts
           cp artifacts/adempiere-report-engine-service.dsc docker/ || echo "Warning: descriptor file not found"
 
       - name: Setup QEMU


### PR DESCRIPTION
Although there should be no `latest` image (since no release marked as `latest` has been generated), it was generated/replaced with the pre-release `test-0.0.1-rc-1`.


