### PR TITLE
feat: Release with branch as dokcer tag.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -14,32 +14,28 @@
 	</classpathentry>
 	<classpathentry kind="src" output="bin/test" path="build/generated/source/proto/test/java">
 		<attributes>
-			<attribute name="protobuf_generated_source" value="true"/>
-			<attribute name="optional" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" output="bin/test" path="build/generated/source/proto/test/grpc">
 		<attributes>
-			<attribute name="protobuf_generated_source" value="true"/>
-			<attribute name="optional" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" output="bin/main" path="build/generated/source/proto/main/java">
 		<attributes>
-			<attribute name="protobuf_generated_source" value="true"/>
-			<attribute name="optional" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" output="bin/main" path="build/generated/source/proto/main/grpc">
 		<attributes>
-			<attribute name="protobuf_generated_source" value="true"/>
-			<attribute name="optional" value="true"/>
-			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ on:
     paths-ignore:
       - README.md
       - README.es.md
+      - docker/*
 
   pull_request:
     branches:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,12 +92,12 @@ jobs:
           tag_name: ${{ github.event.release.tag_name }}
           files: |
             artifacts/adempiere-report-engine-service.dsc
-            artifacts/adempiere-report-engine-service.zip
-            artifacts/adempiere-report-engine-service.zip.MD5
-            artifacts/adempiere-report-engine-service.tar
-            artifacts/adempiere-report-engine-service.tar.MD5
-            artifacts/envoy.yaml
             artifacts/env.yaml
+            artifacts/envoy.yaml
+            artifacts/adempiere-report-engine-service.zip.MD5
+            artifacts/adempiere-report-engine-service.zip
+            artifacts/adempiere-report-engine-service.tar.MD5
+            artifacts/adempiere-report-engine-service.tar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -161,8 +161,15 @@ jobs:
         run: |
           # Get the release type
           IS_PRE_RELEASE=${{ github.event.release.prerelease }}
+
+          # Get branch name from release
+          BRANCH_NAME="${{ github.event.release.target_commitish }}"
+          # clean branch name (clear invalid characters to Docker tags)
+          CLEAN_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g')
+
           # Set the base tags, always include the specific version tag
           TAGS="${{ secrets.DOCKER_HUB_REPO_NAME }}:${{ github.event.release.tag_name }}-alpine"
+          TAGS+=",${{ secrets.DOCKER_HUB_REPO_NAME }}:$CLEAN_BRANCH_NAME-alpine"
           # If it's not a pre-release, add the "latest" tag
           if [[ "$IS_PRE_RELEASE" == "false" ]]; then
             TAGS+=",${{ secrets.DOCKER_HUB_REPO_NAME }}:alpine"
@@ -220,8 +227,15 @@ jobs:
         run: |
           # Get the release type
           IS_PRE_RELEASE=${{ github.event.release.prerelease }}
+
+          # Get branch name from release
+          BRANCH_NAME="${{ github.event.release.target_commitish }}"
+          # clean branch name (clear invalid characters to Docker tags)
+          CLEAN_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g')
+
           # Set the base tags, always include the specific version tag
           TAGS="${{ secrets.DOCKER_HUB_REPO_NAME }}:${{ github.event.release.tag_name }}"
+          TAGS+=",${{ secrets.DOCKER_HUB_REPO_NAME }}:$CLEAN_BRANCH_NAME"
           # If it's not a pre-release, add the "latest" tag
           if [[ "$IS_PRE_RELEASE" == "false" ]]; then
             TAGS+=",${{ secrets.DOCKER_HUB_REPO_NAME }}:latest"
@@ -304,8 +318,15 @@ jobs:
         run: |
           # Get the release type
           IS_PRE_RELEASE=${{ github.event.release.prerelease }}
+
+          # Get branch name from release
+          BRANCH_NAME="${{ github.event.release.target_commitish }}"
+          # clean branch name (clear invalid characters to Docker tags)
+          CLEAN_BRANCH_NAME=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9._-]/-/g')
+
           # Set the base tags, always include the specific version tag
           TAGS="${{ secrets.DOCKER_HUB_PROXY_REPO_NAME }}:${{ github.event.release.tag_name }}"
+          TAGS+=",${{ secrets.DOCKER_HUB_PROXY_REPO_NAME }}:$CLEAN_BRANCH_NAME"
           # If it's not a pre-release, add the "latest" tag
           if [[ "$IS_PRE_RELEASE" == "false" ]]; then
             TAGS+=",${{ secrets.DOCKER_HUB_PROXY_REPO_NAME }}:latest"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # ADempiere Report Engine Service
 
+<p align="center">
+  <a href="https://adoptium.net/es/temurin/releases/?version=17">
+    <img src="https://badgen.net/badge/Java/17/orange" alt="Java">
+  </a>
+  <a href="https://hub.docker.com/r/openls/adempiere-report-engine-service">
+    <img src="https://img.shields.io/docker/pulls/openls/adempiere-report-engine-service.svg" alt="Docker Pulls">
+  </a>
+  <a href="https://github.com/adempiere/adempiere-report-engine-service/actions/workflows/ci.yml">
+    <img src="https://github.com/adempiere/adempiere-report-engine-service/actions/workflows/ci.yml/badge.svg" alt="Build GH Action">
+  </a>
+  <a href="https://github.com/adempiere/adempiere-report-engine-service/blob/master/LICENSE">
+    <img src="https://img.shields.io/badge/license-GNU/GPL%20(v2)-blue" alt="License">
+  </a>
+  <a href="https://github.com/adempiere/adempiere-report-engine-service/releases/latest">
+    <img src="https://img.shields.io/github/release/adempiere/adempiere-report-engine-service.svg" alt="GitHub release">
+  </a>
+  <a href="https://discord.gg/T6eH6A7PJZ">
+    <img src="https://badgen.net/badge/discord/join%20chat" alt="Discord">
+  </a>
+</p>
+
 This project define a new way for consume reports using gRPC inside ADempiere. Currently exists a usefull reporter with a good definition like **Print Format**, This repository don't want replace the current approach, just I try improve this with a new functionality as service with some features like:
 
 - Pagination
@@ -36,6 +57,16 @@ docker pull openls/adempiere-report-engine-service:alpine
 ### Where is the image?
 
 You can find it from [Docker Hub](https://hub.docker.com/r/openls/adempiere-report-engine-service/tags)
+
+#### Image variants
+ * `Eclipse Temurin Alpine` java development kit based:
+   * `docker pull openls/adempiere-report-engine-service:alpine`
+   * `docker pull openls/adempiere-report-engine-service:1.3.8-alpine`
+   * `docker pull openls/adempiere-report-engine-service:main-alpine`
+ * `Eclipse Temurin Noble` java development kit based:
+   * `docker pull openls/adempiere-report-engine-service:latest`
+   * `docker pull openls/adempiere-report-engine-service:1.3.8`
+   * `docker pull openls/adempiere-report-engine-service:main`
 
 ### Minimal Docker Requirements
 To use this Docker image you must have your Docker engine version greater than or equal to 3.0.

--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,6 @@ plugins {
 	id 'application'
 	// Generate Visual Studio Code .vscode & .json project files
 	id 'visual-studio'
-	// Publish artifacts to an Apache Maven repository.
-	id 'maven-publish'
 	// Read .env files
 	id "io.github.uoxx3.project-environment" version "1.0.1"
 }

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -27,7 +27,7 @@ ADEMPIERE_ZK_DB_NAME="adempiere"
 ADEMPIERE_ZK_DB_PASSWORD=${POSTGRES_PASSWORD}
 
 # ADempiere gRPC Template
-GRPC_SERVER_IMAGE="openls/adempiere-report-engine-service:alpine-1.3.2"
+GRPC_SERVER_IMAGE="openls/adempiere-report-engine-service:1.3.8-alpine"
 GRPC_SERVER_HOST="${STACK_NAME}.adempiere.grpc.service"
 GRPC_SERVER_INTERNAL_PORT=50059
 GRPC_SERVER_EXTERNAL_PORT=${GRPC_SERVER_INTERNAL_PORT}


### PR DESCRIPTION
When a GitHub release is generated, a Docker tag will be created with the name of the branch from which the release was made.

Considering that a release is made from the `main` branch, for images based on temurin ubuntu it will be `main` and for images based on temurin alpine it will be `main-apline`.

The README.md documentation has also been improved:

<img width="1241" height="379" alt="imagen" src="https://github.com/user-attachments/assets/8994060d-31b2-41e4-9a5c-5f4234818118" />

<img width="1211" height="430" alt="imagen" src="https://github.com/user-attachments/assets/98476169-7a66-4927-9a47-f45865f3a6c4" />
