### PR TITLE
fix: Order rows with print format not displayed

### DIFF
--- a/src/main/java/org/spin/report_engine/data/Cell.java
+++ b/src/main/java/org/spin/report_engine/data/Cell.java
@@ -112,8 +112,11 @@ public class Cell {
 	}
 
 	public String getCompareValue() {
-		if(value instanceof Timestamp && value != null) {
-			return new SimpleDateFormat("yyyy-MM-dd").format((Timestamp) value);
+		if(value != null && value instanceof Timestamp) {
+			return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format((Timestamp) value);
+		}
+		if(value != null && value instanceof Number) {
+			return String.format("%040.10f", ((Number) value).doubleValue());
 		}
 		if(Util.isEmpty(displayValue)) {
 			if(value != null) {

--- a/src/main/java/org/spin/report_engine/data/ReportInfo.java
+++ b/src/main/java/org/spin/report_engine/data/ReportInfo.java
@@ -240,7 +240,14 @@ public class ReportInfo {
 	private Comparator<Row> getSortingValue(boolean summaryAtEnd) {
 		AtomicReference<Comparator<Row>> comparator = new AtomicReference<>();
 		sortingItems.forEach(printFormatItem -> {
-			Comparator<Row> groupComparator = (p, o) -> p.getCompareValue(printFormatItem.getPrintFormatItemId()).compareToIgnoreCase(o.getCompareValue(printFormatItem.getPrintFormatItemId()));
+			Comparator<Row> groupComparator = (p, o) -> {
+				String pValue = p.getCompareValue(printFormatItem.getPrintFormatItemId());
+				String oValue = o.getCompareValue(printFormatItem.getPrintFormatItemId());
+				if(printFormatItem.isDesc()) {
+					return oValue.compareToIgnoreCase(pValue);
+				}
+				return pValue.compareToIgnoreCase(oValue);
+			};
 			if(comparator.get() == null) {
 				comparator.set(groupComparator);
 			} else {

--- a/src/main/java/org/spin/report_engine/format/PrintFormat.java
+++ b/src/main/java/org/spin/report_engine/format/PrintFormat.java
@@ -171,19 +171,29 @@ public class PrintFormat {
 	public List<PrintFormatItem> getItems() {
 		return items;
 	}
-	
+
 	public List<PrintFormatItem> getPrintedItems() {
-		return items.stream().filter(item -> item.isPrinted()).collect(Collectors.toList());
+		return items.stream()
+			.filter(item -> item.isPrinted())
+			.collect(Collectors.toList())
+		;
 	}
-	
+
 	public List<PrintFormatItem> getGroupItems() {
-		return items.stream().filter(item -> item.isGroupBy()).collect(Collectors.toList());
+		return items.stream()
+			.filter(item -> item.isGroupBy())
+			.collect(Collectors.toList())
+		;
 	}
-	
+
 	public List<PrintFormatItem> getSortingItems() {
-		return items.stream().filter(item -> item.isGroupBy() || item.isOrderBy()).sorted(Comparator.comparing(PrintFormatItem::getSortSequence)).collect(Collectors.toList());
+		return items.stream()
+			.filter(item -> item.isGroupBy() || item.isOrderBy())
+			.sorted(Comparator.comparing(PrintFormatItem::getSortSequence))
+			.collect(Collectors.toList())
+		;
 	}
-	
+
 	public List<PrintFormatColumn> getColumnsDefinition() {
 		return columnsDefinition;
 	}
@@ -196,10 +206,13 @@ public class PrintFormat {
 		Language language = Language.getLoginLanguage();
 		List<PrintFormatColumn> columns = new ArrayList<PrintFormatColumn>();
 		getItems().stream()
-		.filter(item -> item.isActive() && item.isPrinted())
-		.sorted(Comparator.comparing(PrintFormatItem::getSequence))
-		.forEach(item -> {
-			if(item.getColumnId() > 0) {
+			.filter(item -> item.isActive() && item.isPrinted())
+			.sorted(Comparator.comparing(PrintFormatItem::getSequence))
+			.forEach(item -> {
+				if(item.getColumnId() <= 0) {
+					// next loop
+					return;
+				}
 				String columnName = null;
 				String alias = null;
 				if(query.length() > 0) {
@@ -217,6 +230,7 @@ public class PrintFormat {
 					alias = columnName;
 					columns.add(PrintFormatColumn.newInstance(item).withColumnNameAlias(columnName));
 				}
+
 				//	Process Display Value
 				if(item.getReferenceId() == DisplayType.TableDir
 						|| (item.getReferenceId() == DisplayType.Search && item.getReferenceValueId() == 0)) {
@@ -355,20 +369,40 @@ public class PrintFormat {
 					tableReferences.append("AD_Table").append(" ").append(getTableAlias()).append(" ON (")
 					.append(getQueryReferenceColumnName("AD_Table_ID")).append("=").append(getQueryColumnName("AD_Table_ID")).append(")");
 				}
-				//	For Order By
-				if(item.isOrderBy()) {
-					if(!Util.isEmpty(alias)) {
-						if(orderBy.length() > 0) {
-							orderBy.append(", ");
-						}
-						orderBy.append(alias);
-						if(item.isDesc()) {
-							orderBy.append(" DESC");
-						}
+			})
+		;
+
+		//	For Order By
+		getItems().stream()
+			.filter(item -> item.isActive() && item.isOrderBy())
+			.sorted(Comparator.comparing(PrintFormatItem::getSortSequence))
+			.forEach(item -> {
+				if(item.getColumnId() <= 0) {
+					// next loop
+					return;
+				}
+
+				String columnName = null;
+				String alias = null;
+				if(item.isVirtualColumn()) {
+					alias = item.getColumnName();
+				} else {
+					columnName = getQueryColumnName(item.getColumnName());
+					alias = columnName;
+				}
+
+				if(!Util.isEmpty(alias)) {
+					if(orderBy.length() > 0) {
+						orderBy.append(", ");
+					}
+					orderBy.append(alias);
+					if(item.isDesc()) {
+						orderBy.append(" DESC");
 					}
 				}
-			}
-		});
+			});
+		;
+
 		if(getTableName().equals("T_Report")) {
 			//	Level No
 			if(query.length() > 0) {
@@ -390,12 +424,14 @@ public class PrintFormat {
 				query.append(tableReferences);
 			}
 		}
+
 		//	Return definition
 		return QueryDefinition.newInstance()
-				.withQuery(query.toString())
-				.withOrderBy(orderBy.toString())
-				.withColumns(getColumnsDefinition())
-				.withQueryColumns(columns);
+			.withQuery(query.toString())
+			.withOrderBy(orderBy.toString())
+			.withColumns(getColumnsDefinition())
+			.withQueryColumns(columns)
+		;
 	}
 	
 	private String getQueryColumnName(String columnName) {


### PR DESCRIPTION
When multiple print format items are present and one of them is excluded from printing, it results in that item not being taken into account during the sorting process, thereby causing erroneous values ​​or inconsistencies in the sorting order.



### Before this changes


<img width="1915" height="939" alt="image" src="https://github.com/user-attachments/assets/11b4eb41-0274-4595-a688-366dd175451c" />

### After this changes


<img width="1925" height="947" alt="image" src="https://github.com/user-attachments/assets/cebfb944-dcd6-42d0-8a56-6b873431d550" />





### Additional context
Result with Zk-UI


<img width="1917" height="968" alt="image" src="https://github.com/user-attachments/assets/4e1f4f35-af81-4dfc-a302-66b2a068fac7" />




