### PR TITLE
fix: Propagate error when the report class generates a validation error

### DIFF
--- a/src/main/java/org/spin/report_engine/service/ReportBuilder.java
+++ b/src/main/java/org/spin/report_engine/service/ReportBuilder.java
@@ -315,6 +315,9 @@ public class ReportBuilder {
 					.withTransactionName(transactionName)
 					.run()
 				;
+				if (processInfo.isError()) {
+					throw new AdempiereException(processInfo.getSummary());
+				}
 			}
 			validatePrintFormat(transactionName);
 			reportInfo.set(get(transactionName));


### PR DESCRIPTION


```bash
curl 'http://127.0.0.1:85/api/report-engine/reports/2000269?report_type=pdf&filters=%255B%257B%2522name%2522%253A%2522IsSOTrx%2522%252C%2522operator%2522%253A%2522equal%2522%252C%2522values%2522%253Atrue%257D%252C%257B%2522name%2522%253A%2522C_BPartner_ID%2522%252C%2522operator%2522%253A%2522equal%2522%252C%2522values%2522%253A1008069%257D%252C%257B%2522name%2522%253A%2522C_Currency_ID%2522%252C%2522operator%2522%253A%2522equal%2522%252C%2522values%2522%253A142%257D%252C%257B%2522name%2522%253A%2522StartDate%2522%252C%2522operator%2522%253A%2522between%2522%252C%2522values%2522%253A%255B%25222023-03-22%2522%252C%25222026-03-22%2522%255D%257D%252C%257B%2522name%2522%253A%2522AD_Client_ID%2522%252C%2522operator%2522%253A%2522equal%2522%252C%2522values%2522%253A1000001%257D%252C%257B%2522name%2522%253A%2522AD_User_ID%2522%252C%2522operator%2522%253A%2522equal%2522%252C%2522values%2522%253A1001669%257D%255D&page_size=100&page_token=1&is_summary=true' \
  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:149.0) Gecko/20100101 Firefox/149.0' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: es-MX,es;q=0.9,en-US;q=0.8,en;q=0.7' \
  -H 'Accept-Encoding: gzip, deflate, br, zstd' \
  -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiIzMjU0NzA0IiwiQURfQ2xpZW50X0lEIjoxMDAwMDAxLCJBRF9PcmdfSUQiOjEwMDAwMDYsIkFEX1JvbGVfSUQiOjEwMDAwMDIsIkFEX1VzZXJfSUQiOjEwMDE2NjksIk1fV2FyZWhvdXNlX0lEIjoxMDAwMDk5LCJBRF9MYW5ndWFnZSI6ImVzX01YIiwiaWF0IjoxNzc2MzY4ODcwLCJleHAiOjE3NzY0NTUyNzB9.ur9o65Ot0NLEMLeFzbLm4L0wnbw7uDsxW8bYvMQKiRM' \
  -H 'Origin: http://127.0.0.1:9527' \
  -H 'Connection: keep-alive' \
  -H 'Referer: http://127.0.0.1:9527/' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-site' \
  -H 'Priority: u=0'
```


### Before this changes
```json
{
 "id": 1000459,
 "name": "Solop -\u003e Estado de Cuenta Corriente",
 "description": "",
 "print_format_id": 1000459,
 "report_view_id": 2000059,
 "record_count": "0",
 "columns": [
  {
   "code": "1020565",
   "title": "Organización",
   "color": "",
   "style": "",
   "display_type": 19,
   "is_group_column": false,
   "sequence": 10,
   "column_width": 0,
   "column_characters_size": 0,
   "is_fixed_width": false,
   "font_code": "",
   "column_name": "AD_Org_ID",
   "is_hide_grand_total": false
  },
  {
   "code": "1020545",
   "title": "Socio del Negocio",
   "color": "",
   "style": "",
   "display_type": 19,
   "is_group_column": false,
   "sequence": 20,
   "column_width": 0,
   "column_characters_size": 0,
   "is_fixed_width": false,
   "font_code": "",
   "column_name": "C_BPartner_ID",
   "is_hide_grand_total": false
  },
  {
   "code": "1020575",
   "title": "F. Transacción",
   "color": "",
   "style": "",
   "display_type": 16,
   "is_group_column": false,
   "sequence": 30,
   "column_width": 0,
   "column_characters_size": 0,
   "is_fixed_width": false,
   "font_code": "",
   "column_name": "DateTrx",
   "is_hide_grand_total": false
  },
  {
   "code": "1020560",
   "title": "Tipo de Documento",
   "color": "",
   "style": "",
   "display_type": 19,
   "is_group_column": false,
   "sequence": 40,
   "column_width": 0,
   "column_characters_size": 0,
   "is_fixed_width": false,
   "font_code": "",
   "column_name": "C_DocType_ID",
   "is_hide_grand_total": false
  },
  {
   "code": "1020564",
   "title": "Referencia de Orden de Socio del Negocio",
   "color": "",
   "style": "",
   "display_type": 14,
   "is_group_column": false,
   "sequence": 50,
   "column_width": 0,
   "column_characters_size": 0,
   "is_fixed_width": false,
   "font_code": "",
   "column_name": "POReference",
   "is_hide_grand_total": false
  },
  {
   "code": "1020555",
   "title": "Moneda",
   "color": "",
   "style": "",
   "display_type": 19,
   "is_group_column": false,
   "sequence": 60,
   "column_width": 0,
   "column_characters_size": 0,
   "is_fixed_width": false,
   "font_code": "",
   "column_name": "C_Currency_ID",
   "is_hide_grand_total": false
  },
  {
   "code": "1020550",
   "title": "C0024_OpeningBalance",
   "color": "",
   "style": "",
   "display_type": 22,
   "is_group_column": false,
   "sequence": 70,
   "column_width": 0,
   "column_characters_size": 0,
   "is_fixed_width": false,
   "font_code": "",
   "column_name": "C0024_OpeningBalance",
   "is_hide_grand_total": false
  },
  {
   "code": "1020548",
   "title": "C0024_Debit",
   "color": "",
   "style": "",
   "display_type": 22,
   "is_group_column": false,
   "sequence": 80,
   "column_width": 0,
   "column_characters_size": 0,
   "is_fixed_width": false,
   "font_code": "",
   "column_name": "C0024_Debit",
   "is_hide_grand_total": false
  },
  {
   "code": "1020546",
   "title": "C0024_Credit",
   "color": "",
   "style": "",
   "display_type": 22,
   "is_group_column": false,
   "sequence": 90,
   "column_width": 0,
   "column_characters_size": 0,
   "is_fixed_width": false,
   "font_code": "",
   "column_name": "C0024_Credit",
   "is_hide_grand_total": false
  },
  {
   "code": "1020547",
   "title": "C0024_CumulativeBalance",
   "color": "",
   "style": "",
   "display_type": 22,
   "is_group_column": false,
   "sequence": 100,
   "column_width": 0,
   "column_characters_size": 0,
   "is_fixed_width": false,
   "font_code": "",
   "column_name": "C0024_CumulativeBalance",
   "is_hide_grand_total": false
  }
 ],
 "rows": [],
 "next_page_token": "",
 "instance_id": 4873149,
 "table_name": "T_C0024_AccountStatus"
}
```



### After this changes
```json
{
 "code": 13,
 "message": "Debe seleccionar una organización o una corporación para ejecutar el informe.",
 "details": []
}
```


### Additional context
Error log
```
===========> RAccountStatusReceiptRV.process: @C0024_Error2@ [23]
java.lang.Exception: @C0024_Error2@
        at com.solop.core.process.RAccountStatusReceiptRV.doIt(RAccountStatusReceiptRV.java:74)
        at org.compiere.process.SvrProcess.process(SvrProcess.java:177)
        at org.compiere.process.SvrProcess.startProcess(SvrProcess.java:130)
        at org.adempiere.util.ProcessUtil.startJavaProcess(ProcessUtil.java:176)
        at org.spin.report_engine.service.ReportProcessor.startProcess(ReportProcessor.java:212)
        at org.spin.report_engine.service.ReportProcessor.run(ReportProcessor.java:130)
        at org.spin.report_engine.service.ReportBuilder.lambda$7(ReportBuilder.java:336)
        at org.compiere.util.Trx.run(Trx.java:529)
        at org.compiere.util.Trx.run(Trx.java:497)
        at org.spin.report_engine.service.ReportBuilder.run(ReportBuilder.java:330)
        at org.spin.report_engine.service.Service.getReport(Service.java:256)
        at org.spin.report_engine.controller.ReportService.getReport(ReportService.java:58)
        at org.spin.backend.grpc.report_engine.ReportEngineGrpc$MethodHandlers.invoke(ReportEngineGrpc.java:446)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:356)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)

```