### PR TITLE
fix: Ambiguous column reference in virtual column SQL

### DIFF
--- a/src/main/java/org/spin/report_engine/format/PrintFormat.java
+++ b/src/main/java/org/spin/report_engine/format/PrintFormat.java
@@ -17,6 +17,7 @@ package org.spin.report_engine.format;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.adempiere.core.domains.models.I_AD_PrintFormatItem;
@@ -49,6 +50,7 @@ public class PrintFormat {
 	private List<ReportView> reportViews;
 	private List<PrintFormatItem> items;
 	private List<PrintFormatColumn> columnsDefinition;
+	private List<String> baseColumnNames;
 	private int aliasNumber;
 	
 	private PrintFormat(MPrintFormat printFormat) {
@@ -98,12 +100,19 @@ public class PrintFormat {
 		;
 
 		//	Get Columns
+		List<String> baseColumnNames = table.getColumnsAsList()
+			.stream()
+			.filter(column -> Util.isEmpty(column.getColumnSQL(), true))
+			.map(column -> column.getColumnName())
+			.collect(Collectors.toList())
+		;
+		this.baseColumnNames = baseColumnNames;
 		this.columnsDefinition = table.getColumnsAsList()
 			.stream()
 			.map(column -> {
 				String columnName = column.getColumnName();
 				if(!Util.isEmpty(column.getColumnSQL())) {
-					columnName = "(" + column.getColumnSQL() + ")";
+					columnName = "(" + qualifyVirtualColumnSql(column.getColumnSQL()) + ")";
 					return PrintFormatColumn.newInstance(column).withColumnNameAlias(columnName);
 				} else {
 					columnName = getQueryColumnName(column.getColumnName());
@@ -219,7 +228,7 @@ public class PrintFormat {
 					query.append(", ");
 				}
 				if(item.isVirtualColumn()) {
-					columnName = "(" + item.getColumnSql() + ")";
+					columnName = "(" + qualifyVirtualColumnSql(item.getColumnSql()) + ")";
 					query.append(columnName);
 					query.append(" AS ").append(item.getColumnName());
 					alias = item.getColumnName();
@@ -238,7 +247,7 @@ public class PrintFormat {
 						query.append(", ");
 					}
 					if(item.isVirtualColumn()) {
-						columnName = MLookupFactory.getLookup_TableDirEmbed(language, item.getColumnName(), getTableName(), "(" + item.getColumnSql() + ")");
+						columnName = MLookupFactory.getLookup_TableDirEmbed(language, item.getColumnName(), getTableName(), "(" + qualifyVirtualColumnSql(item.getColumnSql()) + ")");
 					} else {
 						columnName = MLookupFactory.getLookup_TableDirEmbed(language, item.getColumnName(), getTableName());
 					}
@@ -437,7 +446,33 @@ public class PrintFormat {
 	private String getQueryColumnName(String columnName) {
 		return getTableName() + "." + columnName;
 	}
-	
+
+
+	/**
+	 * Prefix unqualified references to base table columns inside a virtual column SQL
+	 * with the base table name. This avoids ambiguous column references when the
+	 * generated query introduces joins whose tables share column names with the
+	 * base table (e.g. AD_Table aliased as t2 exposing AD_Table_ID alongside
+	 * T_TrialBalance.AD_Table_ID).
+	 */
+	private String qualifyVirtualColumnSql(String columnSql) {
+		if (Util.isEmpty(columnSql, true) || baseColumnNames == null || baseColumnNames.isEmpty()) {
+			return columnSql;
+		}
+		String result = columnSql;
+		String tablePrefix = getTableName() + ".";
+		for (String columnName : baseColumnNames) {
+			if (Util.isEmpty(columnName, true)) {
+				continue;
+			}
+			// match whole word, not preceded by a word char or '.', case insensitive
+			String regex = "(?i)(?<![\\w.])" + Pattern.quote(columnName) + "(?!\\w)";
+			result = result.replaceAll(regex, tablePrefix + columnName);
+		}
+		return result;
+	}
+
+
 	private String getQueryReferenceColumnName(String columnName) {
 		return getTableAlias() + "." + columnName;
 	}


### PR DESCRIPTION
 `ERROR: column reference "ad_table_id" is ambiguous` raised when a print format includes a virtual column whose `ColumnSQL` references base-table columns unqualified (e.g. `CASE WHEN AD_Table_ID = 318 THEN ... Record_ID ... END`) while `getQuery()` also emits a `LEFT OUTER JOIN AD_Table for Record_ID, causing AD_Table_ID` to collide with the joined alias.

`PrintFormat` now prefixes every unqualified reference to a base-table column inside any virtual column SQL with the base table name (via the new `qualifyVirtualColumnSql` helper), applied in the three places where virtual SQL is embedded: `columnsDefinition` (used for dynamic WHERE), the SELECT clause, and the `MLookupFactory.getLookup_TableDirEmbed` call.

### Additional context
```
===========> TrialBalance.prepare: Unknown Parameter: isShowRetainedEarnings [22]
-----------> QueryDefinition.lambda$1: No column found for condition with column name: isShowRetainedEarnings [22]
-----------> ReportService.getReport: org.postgresql.util.PSQLException: ERROR: column reference "ad_table_id" is ambiguous
  Position: 1472 [22]
org.adempiere.exceptions.AdempiereException: org.postgresql.util.PSQLException: ERROR: column reference "ad_table_id" is ambiguous
  Position: 1472
        at org.spin.report_engine.service.ReportBuilder.lambda$6(ReportBuilder.java:291)
        at io.vavr.control.Try.onFailure(Try.java:659)
        at org.spin.report_engine.service.ReportBuilder.get(ReportBuilder.java:290)
        at org.spin.report_engine.service.ReportBuilder.lambda$7(ReportBuilder.java:323)
        at org.compiere.util.Trx.run(Trx.java:529)
        at org.compiere.util.Trx.run(Trx.java:497)
        at org.spin.report_engine.service.ReportBuilder.run(ReportBuilder.java:310)
        at org.spin.report_engine.service.Service.getReport(Service.java:256)
        at org.spin.report_engine.controller.ReportService.getReport(ReportService.java:58)
        at org.spin.backend.grpc.report_engine.ReportEngineGrpc$MethodHandlers.invoke(ReportEngineGrpc.java:446)
        at io.grpc.stub.ServerCalls$UnaryServerCallHandler$UnaryServerCallListener.onHalfClose(ServerCalls.java:182)
        at io.grpc.PartialForwardingServerCallListener.onHalfClose(PartialForwardingServerCallListener.java:35)
        at io.grpc.ForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:23)
        at io.grpc.ForwardingServerCallListener$SimpleForwardingServerCallListener.onHalfClose(ForwardingServerCallListener.java:40)
        at io.grpc.Contexts$ContextualizedServerCallListener.onHalfClose(Contexts.java:86)
        at io.grpc.internal.ServerCallImpl$ServerStreamListenerImpl.halfClosed(ServerCallImpl.java:356)
        at io.grpc.internal.ServerImpl$JumpToApplicationThreadServerStreamListener$1HalfClosed.runInContext(ServerImpl.java:861)
        at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
        at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: org.postgresql.util.PSQLException: ERROR: column reference "ad_table_id" is ambiguous
  Position: 1472
        at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2675)
        at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2365)
        at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:355)
        at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:490)
        at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:408)
        at org.postgresql.jdbc.PgPreparedStatement.executeWithFlags(PgPreparedStatement.java:166)
        at org.postgresql.jdbc.PgPreparedStatement.executeQuery(PgPreparedStatement.java:118)
        at com.zaxxer.hikari.pool.ProxyPreparedStatement.executeQuery(ProxyPreparedStatement.java:52)
        at com.zaxxer.hikari.pool.HikariProxyPreparedStatement.executeQuery(HikariProxyPreparedStatement.java)
        at jdk.internal.reflect.GeneratedMethodAccessor1.invoke(Unknown Source)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:569)
        at org.compiere.db.StatementProxy.invoke(StatementProxy.java:100)
        at jdk.proxy2/jdk.proxy2.$Proxy6.executeQuery(Unknown Source)
        at org.compiere.util.DB.lambda$static$0(DB.java:2583)
        at io.vavr.control.Try.run(Try.java:118)
        at org.compiere.util.DB.lambda$static$45ffa763$1(DB.java:2577)
        at org.compiere.util.DB.runResultSet(DB.java:2600)
        at org.spin.report_engine.service.ReportBuilder.get(ReportBuilder.java:252)
        ... 19 more
```