### PR TITLE
fix: Financial Report order by export xlsx

### DIFF
--- a/src/main/java/org/spin/report_engine/data/ReportInfo.java
+++ b/src/main/java/org/spin/report_engine/data/ReportInfo.java
@@ -223,10 +223,27 @@ public class ReportInfo {
 	}
 
 	public List<Row> getCompleteRows() {
+		// For T_Report, flatten the already-built hierarchical tree so the
+		// export preserves parent-followed-by-children order regardless of
+		// the print format's sort items (which usually sort by Name and would
+		// otherwise pull all parents to the top).
+		if (isFinancialReport()) {
+			List<Row> flattened = new ArrayList<Row>();
+			getRowsAsTree().forEach(parent -> flattenRow(parent, flattened));
+			return flattened;
+		}
 		return rows.stream()
 			.sorted(getSortingValue(true))
 			.collect(Collectors.toList())
 		;
+	}
+
+	private void flattenRow(Row row, List<Row> out) {
+		out.add(row);
+		List<Row> children = row.getChildren();
+		if (children != null) {
+			children.forEach(child -> flattenRow(child, out));
+		}
 	}
 
 	public List<Row> getSummaryRows() {
@@ -239,6 +256,16 @@ public class ReportInfo {
 
 	private Comparator<Row> getSortingValue(boolean summaryAtEnd) {
 		AtomicReference<Comparator<Row>> comparator = new AtomicReference<>();
+		// For T_Report (financial reports) the canonical order is by SeqNo
+		// (groups each parent line with its detail rows) and then LevelNo
+		// (parent before children). PrintFormat sort items act as tiebreakers
+		// among siblings of the same parent.
+		if (isFinancialReport()) {
+			comparator.set(
+				Comparator.comparing(Row::getSequence)
+					.thenComparing(Row::getLevel)
+			);
+		}
 		sortingItems.forEach(printFormatItem -> {
 			Comparator<Row> groupComparator = (p, o) -> {
 				String pValue = p.getCompareValue(printFormatItem.getPrintFormatItemId());
@@ -329,7 +356,10 @@ public class ReportInfo {
 	}
 
 	private boolean isFinancialReport() {
-		return getTableName().equals("T_Report");
+		return getTableName() != null
+			&& (getTableName().equals("T_Report")
+			|| getTableName().equals("T_ReportStatement"))
+		;
 	}
 
 	/**

--- a/src/main/java/org/spin/report_engine/export/XlsxExporter.java
+++ b/src/main/java/org/spin/report_engine/export/XlsxExporter.java
@@ -171,15 +171,17 @@ public class XlsxExporter implements IReportEngineExporter {
 		//	create header
 		Row headerRow = sheet.createRow(0);
 		List<ColumnInfo> columns = reportInfo.getColumns();
-		IntStream.range(0, columns.size()).forEach(cellNumber -> {
-			Cell sheetCell = headerRow.createCell(cellNumber);
-			ColumnInfo columnInfo = columns.get(cellNumber);
-			String value = Util.stripDiacritics(columnInfo.getTitle());
-			sheetCell.setCellValue(sheet.getWorkbook().getCreationHelper().createRichTextString(value));
-			//
-			CellStyle style = getHeaderStyle(cellNumber);
-			sheetCell.setCellStyle(style);
-		});
+		IntStream.range(0, columns.size())
+			.forEach(cellNumber -> {
+				Cell sheetCell = headerRow.createCell(cellNumber);
+				ColumnInfo columnInfo = columns.get(cellNumber);
+				String value = Util.stripDiacritics(columnInfo.getTitle());
+				sheetCell.setCellValue(sheet.getWorkbook().getCreationHelper().createRichTextString(value));
+				//
+				CellStyle style = getHeaderStyle(cellNumber);
+				sheetCell.setCellStyle(style);
+			})
+		;
 		//	Export content
 		List<org.spin.report_engine.data.Row> rows = reportInfo.isSummary() ? reportInfo.getSummaryRows(): reportInfo.getCompleteRows();
 		IntStream.range(0, rows.size()).forEach(rowNumber -> {

--- a/src/main/java/org/spin/report_engine/format/PrintFormat.java
+++ b/src/main/java/org/spin/report_engine/format/PrintFormat.java
@@ -425,6 +425,16 @@ public class PrintFormat {
 			}
 			query.append("(").append("T_Report.SeqNo").append(")");
 			query.append(" AS ").append("SeqNo");
+			// FinReport assigns each detail row the SeqNo of its parent
+			// PA_ReportLine, so to preserve the hierarchical order (parent
+			// followed by its children) the canonical sort is SeqNo, LevelNo
+			// and any user-defined order acts as a tiebreaker.
+			StringBuffer financialOrderBy = new StringBuffer("T_Report.SeqNo, T_Report.LevelNo");
+			if (orderBy.length() > 0) {
+				financialOrderBy.append(", ").append(orderBy);
+			}
+			orderBy.setLength(0);
+			orderBy.append(financialOrderBy);
 		}
 		if(query.length() > 0) {
 			query.insert(0, "SELECT ");

--- a/src/main/java/org/spin/report_engine/format/QueryDefinition.java
+++ b/src/main/java/org/spin/report_engine/format/QueryDefinition.java
@@ -206,7 +206,8 @@ public class QueryDefinition {
 						return conditionColumnName.equals(column.getColumnName())
 							|| conditionColumnName.equals(column.getColumnName() + "_To");
 					})
-					.sorted(Comparator.comparing(PrintFormatColumn::getColumnNameAlias).reversed())
+					.sorted(Comparator.comparing(PrintFormatColumn::getColumnNameAlias)
+					.reversed())
 					.findFirst()
 				;
 				if(maybeColumn.isPresent()) {
@@ -219,7 +220,12 @@ public class QueryDefinition {
 					String restriction = getRestrictionByOperator(condition, column.getReferenceId());
 					whereClause.append(restriction);
 				} else {
-					log.warning("No column found for condition with column name: " + condition.getColumnName());
+					log.warning(
+						"No column found for condition with column name: " + condition.getColumnName()
+						+ " , operator: " + condition.getOperator()
+						+ " , and value: " + condition.getValue()
+						+ ". This condition will be ignored."
+					);
 				}
 		});
 

--- a/src/main/java/org/spin/report_engine/service/Service.java
+++ b/src/main/java/org/spin/report_engine/service/Service.java
@@ -290,6 +290,7 @@ public class Service {
 			.withPrintFormatId(request.getPrintFormatId())
 			.withReportViewId(request.getReportViewId())
 			.withSummary(request.getIsSummary())
+			.withInstanceId(request.getInstanceId())
 		;
 
 		// Parameters as filters


### PR DESCRIPTION
When export Financial Report generate order by with Sequence and Level.

<img width="939" height="872" alt="imagen" src="https://github.com/user-attachments/assets/6f38a201-03b2-481c-808f-76c652dd7cf5" />
<img width="901" height="750" alt="imagen" src="https://github.com/user-attachments/assets/9d4b9f27-fc19-4882-a082-42112ae4fbb0" />


[800_-_balance_general_2026-04-28_15-26-38.xlsx](https://github.com/user-attachments/files/27178887/800_-_balance_general_2026-04-28_15-26-38.xlsx)



