### PR TITLE
fix: `Cell.equals` returns false when comparing two cells with `null` values

### DIFF
--- a/src/main/java/org/spin/report_engine/data/Cell.java
+++ b/src/main/java/org/spin/report_engine/data/Cell.java
@@ -17,6 +17,7 @@ package org.spin.report_engine.data;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.util.Objects;
 
 import org.compiere.util.Env;
 import org.compiere.util.Util;
@@ -305,24 +306,19 @@ public class Cell {
 
 	@Override
 	public boolean equals(Object object) {
-		if (this.value == object) {
-			// same reference or both null
+		if (this == object) {
 			return true;
-		}
-		if(this.value == null && object == null) {
-			return false;
-		}
-		if(this.value == null && object != null) {
-			return false;
-		}
-		if(this.value != null && object == null) {
-			return false;
 		}
 		if (object == null || this.getClass() != object.getClass()) {
 			return false;
 		}
 		Cell cell = (Cell) object;
-		return this.value.equals(cell.getValue());
+		return Objects.equals(this.value, cell.getValue());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(this.value);
 	}
 
 }

--- a/src/main/java/org/spin/report_engine/format/QueryDefinition.java
+++ b/src/main/java/org/spin/report_engine/format/QueryDefinition.java
@@ -456,7 +456,7 @@ public class QueryDefinition {
 			this.parameters.add(valueToFilter);
 		}
 
-		String rescriction = "(" + columnName + sqlOperator + sqlValue + additionalSQL.toString() + ")";
+		String rescriction = "(" + columnName + " " + sqlOperator + sqlValue + additionalSQL.toString() + ")";
 
 		return rescriction;
 	}

--- a/src/main/java/org/spin/report_engine/service/ReportBuilder.java
+++ b/src/main/java/org/spin/report_engine/service/ReportBuilder.java
@@ -47,6 +47,7 @@ import org.compiere.util.Util;
 import org.spin.report_engine.data.Cell;
 import org.spin.report_engine.data.ReportInfo;
 import org.spin.report_engine.format.PrintFormat;
+import org.spin.report_engine.format.PrintFormatItem;
 import org.spin.report_engine.format.QueryDefinition;
 import org.spin.report_engine.mapper.DefaultMapping;
 import org.spin.report_engine.mapper.IColumnMapping;
@@ -250,35 +251,38 @@ public class ReportBuilder {
 			.withSummary(isSummary())
 		;
 		DB.runResultSet(transactionName, queryDefinition.getCompleteQuery(), queryDefinition.getParameters(), resulset -> {
+			final List<PrintFormatItem> printFormatsList = format.getItems();
 			while (resulset.next()) {
-				format.getItems().forEach(item -> {
+				printFormatsList.forEach(item -> {
 					Map<String, Cell> cells = new HashMap<String, Cell>();
 					queryDefinition.getQueryColumns()
-					.stream()
-					.filter(column -> column.getColumnName().equals(item.getColumnName()))
-					.forEach(column -> {
-						Cell cell = Optional.ofNullable(cells.get(column.getColumnName())).orElse(Cell.newInstance());
-						try {
-							if(column.isDisplayValue()) {
-								cell.withDisplayValue(resulset.getString(column.getColumnNameAlias()));
-							} else {
-								Object value = resulset.getObject(column.getColumnName());
-								cell.withValue(value);
-								//	Apply Default Mask
-								if(!Util.isEmpty(item.getMappingClassName())) {
-									IColumnMapping customMapping = ClassLoaderMapping.loadClass(item.getMappingClassName());
-									if(customMapping != null) {
-										customMapping.processValue(item, column, language, resulset, cell);
-									}
+						.stream()
+						.filter(column -> {
+							return column.getColumnName().equals(item.getColumnName());
+						})
+						.forEach(column -> {
+							Cell cell = Optional.ofNullable(cells.get(column.getColumnName())).orElse(Cell.newInstance());
+							try {
+								if(column.isDisplayValue()) {
+									cell.withDisplayValue(resulset.getString(column.getColumnNameAlias()));
 								} else {
-									DefaultMapping.newInstance().processValue(item, column, language, resulset, cell);
+									Object value = resulset.getObject(column.getColumnName());
+									cell.withValue(value);
+									//	Apply Default Mask
+									if(!Util.isEmpty(item.getMappingClassName())) {
+										IColumnMapping customMapping = ClassLoaderMapping.loadClass(item.getMappingClassName());
+										if(customMapping != null) {
+											customMapping.processValue(item, column, language, resulset, cell);
+										}
+									} else {
+										DefaultMapping.newInstance().processValue(item, column, language, resulset, cell);
+									}
 								}
+							} catch (Exception e) {
+								logger.warning(e.getLocalizedMessage());
 							}
-						} catch (Exception e) {
-							logger.warning(e.getLocalizedMessage());
-						}
-						cells.put(item.getColumnName(), cell);
-					});
+							cells.put(item.getColumnName(), cell);
+						});
 					reportInfo.addCell(item, cells.get(item.getColumnName()));
 				});
 				if(format.getTableName().equals("T_Report")) {

--- a/src/main/java/org/spin/report_engine/service/ReportBuilder.java
+++ b/src/main/java/org/spin/report_engine/service/ReportBuilder.java
@@ -282,7 +282,8 @@ public class ReportBuilder {
 								logger.warning(e.getLocalizedMessage());
 							}
 							cells.put(item.getColumnName(), cell);
-						});
+						})
+					;
 					reportInfo.addCell(item, cells.get(item.getColumnName()));
 				});
 				if(format.getTableName().equals("T_Report")) {


### PR DESCRIPTION
The previous implementation of `Cell.equals` was comparing `this.value` (the internal value) against `object` (the other Cell instance) instead of against the other cell's value. As a result, two cells whose `value` was `null` were never considered equal.

This broke `ReportInfo.compareRows()` whenever the grouping column had `null` values: `processChildren` could not match data rows to their parent summary row, so `getRowsAsTree()` returned a parent with an empty `children` list even though the data was present in `getCompleteRows()`.

The fix replaces the incorrect chain of null checks with the canonical Java `equals` pattern, using `Objects.equals(this.value, cell.getValue())` to handle null values correctly on either side. A consistent `hashCode()` based on the value is also added, since `SummaryHandler` uses `Row` instances (which derive their hash from cells) as `Map` keys.


### Before this changes

<img width="1866" height="839" alt="imagen" src="https://github.com/user-attachments/assets/19957e5d-26b7-45d6-80a2-3e64dd7ef55b" />


### After this changes

<img width="1863" height="852" alt="imagen" src="https://github.com/user-attachments/assets/c74c272b-c3a1-4086-bd07-14f56b4dec78" />
