### PR TITLE
fix: Export empty record

### DIFF
--- a/src/main/java/org/spin/report_engine/format/QueryDefinition.java
+++ b/src/main/java/org/spin/report_engine/format/QueryDefinition.java
@@ -19,6 +19,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
+import org.adempiere.core.domains.models.I_AD_PInstance;
 import org.compiere.model.MRole;
 import org.compiere.model.MTable;
 import org.compiere.util.CLogger;
@@ -232,13 +233,15 @@ public class QueryDefinition {
 		// always restrict by the current instance
 		if (getInstanceId() > 0 && !Util.isEmpty(getTableName(), true)) {
 			MTable table = MTable.get(Env.getCtx(), getTableName());
-			if (table != null && table.getColumn("AD_PInstance_ID") != null) {
+			if (table != null && table.getColumn(I_AD_PInstance.COLUMNNAME_AD_PInstance_ID) != null) {
 				// TODO: Improve add 1=1 to remove `if (whereClause.length() > 0)`
 				if (whereClause.length() > 0) {
 					whereClause.append(" AND ");
 				}
 				whereClause.append(getTableName())
-					.append(".AD_PInstance_ID=")
+					.append(".")
+					.append(I_AD_PInstance.COLUMNNAME_AD_PInstance_ID)
+					.append("=")
 					.append(getInstanceId())
 				;
 			} else {

--- a/src/main/java/org/spin/report_engine/service/ReportBuilder.java
+++ b/src/main/java/org/spin/report_engine/service/ReportBuilder.java
@@ -142,7 +142,7 @@ public class ReportBuilder {
 	public ReportBuilder withInstanceId(int instanceId) {
 		this.instanceId = instanceId;
 		if(instanceId > 0) {
-			withParameter(I_AD_PInstance.COLUMNNAME_AD_PInstance_ID, instanceId);
+			// withParameter(I_AD_PInstance.COLUMNNAME_AD_PInstance_ID, instanceId);
 		}
 		return this;
 	}

--- a/src/main/java/org/spin/report_engine/service/Service.java
+++ b/src/main/java/org/spin/report_engine/service/Service.java
@@ -290,7 +290,7 @@ public class Service {
 			.withPrintFormatId(request.getPrintFormatId())
 			.withReportViewId(request.getReportViewId())
 			.withSummary(request.getIsSummary())
-			.withInstanceId(request.getInstanceId())
+			// .withInstanceId(request.getInstanceId())
 		;
 
 		// Parameters as filters


### PR DESCRIPTION
A restriction is generated using the AD_PInstance_ID with different identifiers
```sql
SELECT
	T_Report.Name,
	T_Report.Description,
	T_Report.Col_0,
	T_Report.Col_1,
	T_Report.Col_2,
	(T_Report.LevelNo) AS LevelNo,
	(T_Report.SeqNo) AS SeqNo

FROM T_Report

WHERE
	(T_Report.AD_PInstance_ID= 4974460 )
	AND (T_Report.AD_PInstance_ID= 4974462 )
	AND T_Report.AD_PInstance_ID=4974462

ORDER BY T_Report.SeqNo, T_Report.LevelNo, T_Report.SeqNo, T_Report.LevelNo, T_Report.Name
```


<img width="901" height="883" alt="imagen" src="https://github.com/user-attachments/assets/271aca33-54ca-4b76-8d98-2e5a28cae1ba" />
