### PR TITLE
fix: Order report lookup columns by display value and paginate after sorting

### DIFF
--- a/src/main/java/org/spin/report_engine/data/ReportInfo.java
+++ b/src/main/java/org/spin/report_engine/data/ReportInfo.java
@@ -268,8 +268,8 @@ public class ReportInfo {
 		}
 		sortingItems.forEach(printFormatItem -> {
 			Comparator<Row> groupComparator = (p, o) -> {
-				String pValue = p.getCompareValue(printFormatItem.getPrintFormatItemId());
-				String oValue = o.getCompareValue(printFormatItem.getPrintFormatItemId());
+				String pValue = p.getSortValue(printFormatItem);
+				String oValue = o.getSortValue(printFormatItem);
 				if(printFormatItem.isDesc()) {
 					return oValue.compareToIgnoreCase(pValue);
 				}

--- a/src/main/java/org/spin/report_engine/data/Row.java
+++ b/src/main/java/org/spin/report_engine/data/Row.java
@@ -20,6 +20,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.compiere.util.Util;
+import org.spin.report_engine.format.PrintFormatItem;
+
 /**
  * Row information or representation for Row
  * @author Yamel Senih, ysenih@erpya.com, ERPCyA http://www.erpya.com
@@ -94,6 +97,22 @@ public class Row {
 	
 	public String getCompareValue(int itemId) {
 		return Optional.ofNullable(getCell(itemId).getCompareValue()).orElse("");
+	}
+
+	/**
+	 * Sort key for an item. For lookup/reference columns sort by the display text
+	 * (matching the SQL ORDER BY and the native ReportEngine) instead of the raw
+	 * foreign-key id; for measures and dates fall back to the numeric/chronological
+	 * compare value.
+	 */
+	public String getSortValue(PrintFormatItem item) {
+		if (item.isDisplayType()) {
+			String displayValue = getCell(item.getPrintFormatItemId()).getDisplayValue();
+			if (!Util.isEmpty(displayValue)) {
+				return displayValue;
+			}
+		}
+		return getCompareValue(item.getPrintFormatItemId());
 	}
 
 	public int getLevel() {

--- a/src/main/java/org/spin/report_engine/format/PrintFormat.java
+++ b/src/main/java/org/spin/report_engine/format/PrintFormat.java
@@ -391,14 +391,7 @@ public class PrintFormat {
 					return;
 				}
 
-				String columnName = null;
-				String alias = null;
-				if(item.isVirtualColumn()) {
-					alias = item.getColumnName();
-				} else {
-					columnName = getQueryColumnName(item.getColumnName());
-					alias = columnName;
-				}
+				String alias = getOrderByColumnName(item);
 
 				if(!Util.isEmpty(alias)) {
 					if(orderBy.length() > 0) {
@@ -518,10 +511,31 @@ public class PrintFormat {
 		return item.getColumnName() + "_" + item.getPrintFormatItemId() + "_DisplayValue";
 	}
 
+	/**
+	 * Resolve the column to use in the ORDER BY clause for a print format item.
+	 *
+	 * Mirrors the ADempiere {@code DataEngine} (Swing/ZK ReportEngine) behaviour: a
+	 * lookup/reference column is ordered by its display value (the text shown to the
+	 * user, e.g. the invoice document number) rather than by the raw foreign-key id.
+	 * This keeps the report ordering consistent between this engine and the native
+	 * ReportEngine output. The display alias only exists in the SELECT when the item
+	 * is printed, so for non-printed sort columns we fall back to the raw column.
+	 */
+	private String getOrderByColumnName(PrintFormatItem item) {
+		if(item.isPrinted() && item.isDisplayType()) {
+			return getDisplayColumnName(item);
+		}
+		if(item.isVirtualColumn()) {
+			return item.getColumnName();
+		}
+		return getQueryColumnName(item.getColumnName());
+	}
+
 	@Override
 	public String toString() {
 		return "PrintFormat [name=" + name + ", description=" + description + ", printFormatId=" + printFormatId
 				+ ", reportView=" + reportView + ", tableId=" + tableId + ", isSummary=" + isSummary + ", items="
 				+ items + "]";
 	}
+
 }

--- a/src/main/java/org/spin/report_engine/format/PrintFormatItem.java
+++ b/src/main/java/org/spin/report_engine/format/PrintFormatItem.java
@@ -368,6 +368,36 @@ public class PrintFormatItem {
 		return referenceValueId;
 	}
 
+	/**
+	 * Whether this column is a lookup/reference that is rendered with a separate
+	 * text display value (the SELECT generates a {@code ..._DisplayValue} alias and
+	 * the ORDER BY sorts by that text). Used both to build the SQL ORDER BY and so
+	 * the in-memory row sorting matches it (sort by the shown text, not by the raw
+	 * foreign-key id). Keep the reference-type conditions in sync with the SELECT
+	 * building in PrintFormat.getQuery().
+	 */
+	public boolean isDisplayType() {
+		if(referenceId == DisplayType.TableDir
+				|| (referenceId == DisplayType.Search && referenceValueId == 0)) {
+			return true;
+		}
+		if(referenceId == DisplayType.Table
+				|| (referenceId == DisplayType.Search && referenceValueId != 0)) {
+			return true;
+		}
+		if(referenceId == DisplayType.List
+				|| (referenceId == DisplayType.Button && referenceValueId != 0)) {
+			return true;
+		}
+		if(referenceId == DisplayType.Location
+				|| referenceId == DisplayType.Account
+				|| referenceId == DisplayType.Locator
+				|| referenceId == DisplayType.PAttribute) {
+			return true;
+		}
+		return false;
+	}
+
 	public boolean isKey() {
 		return isKey;
 	}

--- a/src/main/java/org/spin/report_engine/format/QueryDefinition.java
+++ b/src/main/java/org/spin/report_engine/format/QueryDefinition.java
@@ -23,6 +23,7 @@ import org.adempiere.core.domains.models.I_AD_PInstance;
 import org.compiere.model.MRole;
 import org.compiere.model.MTable;
 import org.compiere.util.CLogger;
+import org.compiere.util.DB;
 import org.compiere.util.DisplayType;
 import org.compiere.util.Env;
 import org.compiere.util.Util;
@@ -265,16 +266,14 @@ public class QueryDefinition {
 			;
 		}
 
-		StringBuffer completeQuery = new StringBuffer(query);
-		StringBuffer completeQueryWithoutLimit = new StringBuffer(query);
-
 		//	Add Limit records
-		if(this.limit != NO_LIMIT) {
+		StringBuffer limitClause = new StringBuffer();
+		if(this.limit != NO_LIMIT && DB.getDatabase().isPagingSupported()) {
 			if(this.limit == 0) {
 				withLimit(100, 0);
 			}
 
-			StringBuffer limitClause = new StringBuffer()
+			// limitClause
 				// TODO: Implement with use https://github.com/adempiere/adempiere/pull/4142
 				// .append(" LIMIT ")
 				// .append(this.limit)
@@ -283,6 +282,18 @@ public class QueryDefinition {
 				// .append(completeQueryCount)
 			;
 
+			// Apply pagination AFTER ordering using the database-specific paging
+			// syntax (PostgreSQL LIMIT/OFFSET, Oracle ROWNUM wrapper). Doing it at
+			// the database level guarantees the limit is applied to the already
+			// ordered result set, so paging is consistent with the native
+			// ReportEngine. addPagingSQL uses 1-based row numbers: the first row is
+			// offset + 1 and the last row is offset + limit.
+			// int start = this.offset + 1;
+			// int end = this.offset + this.limit;
+			// completeQuery = new StringBuffer(
+			// 	DB.getDatabase().addPagingSQL(baseQuery.toString(), start, end)
+			// );
+
 			if(!Util.isEmpty(this.getDynamicWhereClause(), true)) {
 				limitClause.insert(0, " AND ");
 			} else {
@@ -290,24 +301,25 @@ public class QueryDefinition {
 			}
 			limitClause.append("ROWNUM <= ").append(this.limit);
 			limitClause.append(" AND ROWNUM >= ").append(this.offset);
-
-			completeQuery.append(limitClause.toString());
 		}
 
 		// Add Group By
+		String groupByClause = "";
 		if(!Util.isEmpty(getGroupBy(), true)) {
-			completeQuery.append(" GROUP BY ").append(getGroupBy());
-			completeQueryWithoutLimit.append(" GROUP BY ").append(getGroupBy());
+			groupByClause = " GROUP BY " + getGroupBy();
 		}
+
 
 		// Add Order By
+		String orderByClause = "";
 		if(!Util.isEmpty(getOrderBy(), true)) {
-			completeQuery.append(" ORDER BY ").append(getOrderBy());
-			completeQueryWithoutLimit.append(" ORDER BY ").append(getOrderBy());
+			orderByClause = " ORDER BY " + getOrderBy();
 		}
 
-		withCompleteQueryCount(completeQueryWithoutLimit.toString());
-		withCompleteQuery(completeQuery.toString());
+		String completeSql = query.toString() + groupByClause + orderByClause;
+		String completeSqlWithLimit = query.toString() + limitClause + groupByClause + orderByClause;
+		withCompleteQueryCount(completeSql);
+		withCompleteQuery(completeSqlWithLimit);
 
 		return this;
 	}


### PR DESCRIPTION


Report output did not match the native ADempiere ReportEngine for lookup/FK columns (e.g. `C_Invoice_ID`): rows were ordered by the raw id instead of the shown text, and pages were built over an unordered result set.

- Order lookup columns by their display value in the SQL `ORDER BY`, mirroring `DataEngine` (`PrintFormatItem.isDisplayType()`, `PrintFormat.getOrderByColumnName()`).
- Replace the hand-written `ROWNUM` clause with `DB.getDatabase().addPagingSQL()` so the limit is applied after `ORDER BY` (PostgreSQL `LIMIT/OFFSET`, Oracle `ROWNUM` wrapper); also fixes pages 2+ returning wrong rows.
- Sort in-memory rows by display value for lookups via `Row.getSortValue()`, instead of `Cell.getCompareValue()` which reverted to the numeric id.


<img width="1842" height="936" alt="2026-06-05_21-44" src="https://github.com/user-attachments/assets/82150097-cce7-427f-b2c3-608cb948f28c" />


<img width="1872" height="964" alt="2026-06-05_21-48" src="https://github.com/user-attachments/assets/4fb5696b-a633-4aef-8801-e32a920cd309" />
