### PR TITLE
 fix: avoid redundant COUNT pass and stream large report exports

### DIFF
--- a/src/main/java/org/spin/report_engine/data/ReportInfo.java
+++ b/src/main/java/org/spin/report_engine/data/ReportInfo.java
@@ -62,6 +62,7 @@ public class ReportInfo {
 	private int instanceId;
 	private PrintFormat printFormat;
 	private String tableName;
+	private String exportFileName;
 
 	private ReportInfo(PrintFormat printFormat, QueryDefinition queryDefinition) {
 		this.printFormat = printFormat;
@@ -216,6 +217,33 @@ public class ReportInfo {
 		}
 		temporaryRow.withCell(printFormatItem.getPrintFormatItemId(), cell);
 		return this;
+	}
+
+	/**
+	 * Materialize the currently accumulated row as a flat detail row and reset the
+	 * accumulator WITHOUT retaining it in the rows list. Used by the streaming export
+	 * path so the whole result set is never held in memory. Only valid for flat
+	 * reports (no group-by / summary, where subtotals would need the full dataset).
+	 */
+	public Row drainRow() {
+		Row row = null;
+		if(temporaryRow != null) {
+			row = Row.newInstance()
+				.withLevel(getLevel())
+				.withCells(temporaryRow.getData())
+			;
+		}
+		temporaryRow = Row.newInstance().withLevel(getLevel());
+		return row;
+	}
+
+	public ReportInfo withExportFileName(String exportFileName) {
+		this.exportFileName = exportFileName;
+		return this;
+	}
+
+	public String getExportFileName() {
+		return exportFileName;
 	}
 
 	public List<Row> getRows() {

--- a/src/main/java/org/spin/report_engine/export/XlsxExporter.java
+++ b/src/main/java/org/spin/report_engine/export/XlsxExporter.java
@@ -94,10 +94,14 @@ public class XlsxExporter implements IReportEngineExporter {
 		return language;
 	}
 	
-	private Sheet createSheet() {
+	private Sheet createSheet(boolean trackForAutoSize) {
 		SXSSFSheet sheet = (SXSSFSheet) workBook.createSheet();
 		formatPage(sheet);
-		sheet.trackAllColumnsForAutoSizing();
+		//	Auto-size tracking keeps every row's rendered data in memory, which defeats the
+		//	streaming export; only enable it for the buffered path.
+		if(trackForAutoSize) {
+			sheet.trackAllColumnsForAutoSizing();
+		}
 		createHeaderFooter(sheet);
 		return sheet;
 	}
@@ -167,10 +171,71 @@ public class XlsxExporter implements IReportEngineExporter {
 	public String export(ReportInfo reportInfo) {
 		setReportInfo(reportInfo);
 		//	Create Sheet with report info name
-		Sheet sheet = createSheet();
-		//	create header
-		Row headerRow = sheet.createRow(0);
+		Sheet sheet = createSheet(true);
 		List<ColumnInfo> columns = reportInfo.getColumns();
+		//	create header
+		writeHeader(sheet, columns);
+		//	Export content
+		List<org.spin.report_engine.data.Row> rows = reportInfo.isSummary()
+			? reportInfo.getSummaryRows()
+			: reportInfo.getCompleteRows()
+		;
+		IntStream.range(0, rows.size()).forEach(rowNumber ->
+			writeDataRow(sheet, columns, rows.get(rowNumber), rowNumber + 1)
+		);
+		IntStream.range(0, columns.size())
+			.forEach(columnNumber -> sheet.autoSizeColumn(columnNumber))
+		;
+		sheet.createFreezePane(0, 1);
+		return writeFile();
+	}
+
+	//	==== Streaming export ====
+	//	Writes the file row by row (header, then each data row) so the full result set
+	//	is never held in memory. The caller pushes rows via writeStreamRow().
+	private Sheet streamSheet;
+	private List<ColumnInfo> streamColumns;
+	private int streamRowCount;
+
+	/**
+	 * Begin a streaming export: prepare the sheet and write the header. Column auto-sizing
+	 * is disabled (it would require keeping every row in memory); a fixed width is applied
+	 * on {@link #finishStream()}.
+	 */
+	public XlsxExporter beginStream(ReportInfo reportInfo) {
+		setReportInfo(reportInfo);
+		streamSheet = createSheet(false);
+		streamColumns = reportInfo.getColumns();
+		streamRowCount = 0;
+		writeHeader(streamSheet, streamColumns);
+		return this;
+	}
+
+	/**
+	 * Write a single data row to the streaming sheet. SXSSF flushes older rows to disk
+	 * automatically, so memory stays bounded.
+	 */
+	public void writeStreamRow(org.spin.report_engine.data.Row row) {
+		if(row == null) {
+			return;
+		}
+		writeDataRow(streamSheet, streamColumns, row, ++streamRowCount);
+	}
+
+	/**
+	 * Finish the streaming export: apply a fixed column width (auto-size is unavailable once
+	 * rows have been flushed), freeze the header and write the file.
+	 */
+	public String finishStream() {
+		IntStream.range(0, streamColumns.size())
+			.forEach(columnNumber -> streamSheet.setColumnWidth(columnNumber, 20 * 256))
+		;
+		streamSheet.createFreezePane(0, 1);
+		return writeFile();
+	}
+
+	private void writeHeader(Sheet sheet, List<ColumnInfo> columns) {
+		Row headerRow = sheet.createRow(0);
 		IntStream.range(0, columns.size())
 			.forEach(cellNumber -> {
 				Cell sheetCell = headerRow.createCell(cellNumber);
@@ -182,100 +247,93 @@ public class XlsxExporter implements IReportEngineExporter {
 				sheetCell.setCellStyle(style);
 			})
 		;
-		//	Export content
-		List<org.spin.report_engine.data.Row> rows = reportInfo.isSummary() ? reportInfo.getSummaryRows(): reportInfo.getCompleteRows();
-		IntStream.range(0, rows.size()).forEach(rowNumber -> {
-			Row sheetRow = sheet.createRow(rowNumber + 1);
-			IntStream.range(0, columns.size()).forEach(columnNumber -> {
-				Cell sheetCell = sheetRow.createCell(columnNumber);
-				ColumnInfo columnInfo = columns.get(columnNumber);
-				org.spin.report_engine.data.Row rowValue = rows.get(rowNumber);
-				org.spin.report_engine.data.Cell cell = rowValue.getCell(columnInfo.getPrintFormatItemId());
-				//	Apply Default Mask
-				if(!Util.isEmpty(columnInfo.getMappingClassName())) {
-					IColumnMapping customMapping = ClassLoaderMapping.loadClass(columnInfo.getMappingClassName());
-					if(customMapping != null) {
-						customMapping.processValue(
-							columnInfo.getPrintformatItem(),
-							language,
-							cell
-						);
+	}
+
+	private void writeDataRow(Sheet sheet, List<ColumnInfo> columns, org.spin.report_engine.data.Row rowValue, int sheetRowIndex) {
+		Row sheetRow = sheet.createRow(sheetRowIndex);
+		IntStream.range(0, columns.size()).forEach(columnNumber -> {
+			Cell sheetCell = sheetRow.createCell(columnNumber);
+			ColumnInfo columnInfo = columns.get(columnNumber);
+			org.spin.report_engine.data.Cell cell = rowValue.getCell(columnInfo.getPrintFormatItemId());
+			//	Apply Default Mask
+			if(!Util.isEmpty(columnInfo.getMappingClassName())) {
+				IColumnMapping customMapping = ClassLoaderMapping.loadClass(columnInfo.getMappingClassName());
+				if(customMapping != null) {
+					customMapping.processValue(
+						columnInfo.getPrintformatItem(),
+						language,
+						cell
+					);
+				}
+			} else {
+				DefaultMapping.newInstance()
+					.processValue(
+						columnInfo.getPrintformatItem(),
+						language,
+						cell
+					)
+				;
+			}
+			int displayType = columnInfo.getDisplayTypeId();
+			Object valueasObject = cell.getValue();
+			if(valueasObject != null) {
+				if (DisplayType.isDate(displayType)) {
+					Timestamp value = TimeManager.getTimestampFromObject(valueasObject);
+					sheetCell.setCellValue(value);
+				} else if (DisplayType.isNumeric(displayType)) {
+					double value = 0;
+					if (valueasObject instanceof Number) {
+						value = ((Number) valueasObject).doubleValue();
 					}
+					sheetCell.setCellValue(value);
+				} else if (DisplayType.YesNo == displayType) {
+					String value = Util.stripDiacritics(cell.getDisplayValue());
+					sheetCell.setCellValue(
+						sheet.getWorkbook().getCreationHelper().createRichTextString(value)
+					);
 				} else {
-					DefaultMapping.newInstance()
-						.processValue(
-							columnInfo.getPrintformatItem(),
-							language,
-							cell
-						)
-					;
-				}
-				int displayType = columnInfo.getDisplayTypeId();
-				Object valueasObject = cell.getValue();
-				if(valueasObject != null) {
-					if (DisplayType.isDate(displayType)) {
-						Timestamp value = TimeManager.getTimestampFromObject(valueasObject);
-						sheetCell.setCellValue(value);
-					} else if (DisplayType.isNumeric(displayType)) {
-						double value = 0;
-						if (valueasObject instanceof Number) {
-							value = ((Number) valueasObject).doubleValue();
-						}
-						sheetCell.setCellValue(value);
-					} else if (DisplayType.YesNo == displayType) {
-						String value = Util.stripDiacritics(cell.getDisplayValue());
-						sheetCell.setCellValue(
-							sheet.getWorkbook().getCreationHelper().createRichTextString(value)
-						);
-					} else {
-						String displayValue = cell.getDisplayValue();
-						if(Util.isEmpty(displayValue)) {
-							if(!DisplayType.isLookup(displayType)) {
-								if(valueasObject instanceof BigDecimal) {
-									sheetCell.setCellValue(
-										((BigDecimal) valueasObject).doubleValue()
-									);
-								} else if (valueasObject instanceof Integer) {
-									sheetCell.setCellValue(
-										(Integer) valueasObject
-									);
-								} else if (valueasObject instanceof String) {
-									displayValue = (String) valueasObject;
-									displayValue = Util.stripDiacritics(displayValue);
-									sheetCell.setCellValue(
-										sheet.getWorkbook().getCreationHelper().createRichTextString(displayValue)
-									);
-								} else if (valueasObject instanceof Boolean) {
-									sheetCell.setCellValue((Boolean) valueasObject);
-								} else if(valueasObject instanceof Timestamp) {
-									Timestamp value = (Timestamp) valueasObject;
-									sheetCell.setCellValue(value);
-								}
+					String displayValue = cell.getDisplayValue();
+					if(Util.isEmpty(displayValue)) {
+						if(!DisplayType.isLookup(displayType)) {
+							if(valueasObject instanceof BigDecimal) {
+								sheetCell.setCellValue(
+									((BigDecimal) valueasObject).doubleValue()
+								);
+							} else if (valueasObject instanceof Integer) {
+								sheetCell.setCellValue(
+									(Integer) valueasObject
+								);
+							} else if (valueasObject instanceof String) {
+								displayValue = (String) valueasObject;
+								displayValue = Util.stripDiacritics(displayValue);
+								sheetCell.setCellValue(
+									sheet.getWorkbook().getCreationHelper().createRichTextString(displayValue)
+								);
+							} else if (valueasObject instanceof Boolean) {
+								sheetCell.setCellValue((Boolean) valueasObject);
+							} else if(valueasObject instanceof Timestamp) {
+								Timestamp value = (Timestamp) valueasObject;
+								sheetCell.setCellValue(value);
 							}
-						} else {
-							displayValue = Util.stripDiacritics(displayValue);
-							sheetCell.setCellValue(
-								sheet.getWorkbook().getCreationHelper().createRichTextString(displayValue)
-							);
 						}
+					} else {
+						displayValue = Util.stripDiacritics(displayValue);
+						sheetCell.setCellValue(
+							sheet.getWorkbook().getCreationHelper().createRichTextString(displayValue)
+						);
 					}
 				}
-				//
-				CellStyle style = getStyle(
-					rowNumber,
-					columnNumber,
-					rowValue.isSummaryRow(),
-					displayType,
-					null
-				);
-				sheetCell.setCellStyle(style);
-			});
+			}
+			//
+			CellStyle style = getStyle(
+				sheetRowIndex,
+				columnNumber,
+				rowValue.isSummaryRow(),
+				displayType,
+				null
+			);
+			sheetCell.setCellStyle(style);
 		});
-		IntStream.range(0, columns.size())
-			.forEach(columnNumber -> sheet.autoSizeColumn(columnNumber))
-		;
-		sheet.createFreezePane(0, 1);
-		return writeFile();
 	}
 	
 	private CellStyle getHeaderStyle(int col) {

--- a/src/main/java/org/spin/report_engine/service/ReportBuilder.java
+++ b/src/main/java/org/spin/report_engine/service/ReportBuilder.java
@@ -14,6 +14,8 @@
  ************************************************************************************/
 package org.spin.report_engine.service;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -39,6 +41,7 @@ import org.compiere.print.MPrintFormat;
 import org.compiere.process.ProcessInfo;
 import org.compiere.process.ProcessInfoUtil;
 import org.compiere.util.CLogger;
+import org.compiere.util.CPreparedStatement;
 import org.compiere.util.DB;
 import org.compiere.util.Env;
 import org.compiere.util.Language;
@@ -46,6 +49,7 @@ import org.compiere.util.Trx;
 import org.compiere.util.Util;
 import org.spin.report_engine.data.Cell;
 import org.spin.report_engine.data.ReportInfo;
+import org.spin.report_engine.export.XlsxExporter;
 import org.spin.report_engine.format.PrintFormat;
 import org.spin.report_engine.format.PrintFormatItem;
 import org.spin.report_engine.format.QueryDefinition;
@@ -74,11 +78,22 @@ public class ReportBuilder {
 	private int limit;
 	private int offset;
 	private int instanceId;
-	
+	private XlsxExporter streamingExporter;
+
 	private static final CLogger logger = CLogger.getCLogger(ReportBuilder.class);
-	
+
 	private ReportBuilder() {
 		conditions = new ArrayList<Filter>();
+	}
+
+	/**
+	 * Provide an exporter so a full (non-paginated) export of a flat report can be
+	 * streamed row by row instead of materializing the whole result set in memory.
+	 * When null (or for paginated / summary / grouped reports) the buffered path is used.
+	 */
+	public ReportBuilder withStreamingExporter(XlsxExporter streamingExporter) {
+		this.streamingExporter = streamingExporter;
+		return this;
 	}
 
 	public List<Filter> getFilters() {
@@ -271,50 +286,36 @@ public class ReportBuilder {
 			.withLimit(limit, offset)
 			.buildQuery()
 		;
-		//	Count
-		int count = CountUtil.countRecords(queryDefinition.getCompleteQueryCount(), format.getTableName(), queryDefinition.getParameters(), transactionName);
+		boolean paginated = (limit != QueryDefinition.NO_LIMIT);
 		ReportInfo reportInfo = ReportInfo.newInstance(format, queryDefinition)
 			.withReportViewId(getReportViewId())
 			.withInstanceId(getInstanceId())
-			.withRecordCount(count)
 			.withSummary(isSummary())
 		;
+		final List<PrintFormatItem> printFormatsList = format.getItems();
+		//	Streaming export: for a full (non-paginated) export of a flat report we can write
+		//	each row straight to the file and discard it, instead of materializing the whole
+		//	result set in memory. Grouped / summary / financial (T_Report) reports still need
+		//	the full set in memory to build their subtotals, so they keep the buffered path.
+		boolean streamingExport = streamingExporter != null
+			&& !paginated
+			&& !isSummary()
+			&& !"T_Report".equals(format.getTableName())
+			&& format.getGroupItems().isEmpty();
+		if (streamingExport) {
+			runStreamingExport(format, queryDefinition, reportInfo, transactionName, language);
+			return reportInfo.completeInfo();
+		}
+		//	Count: COUNT(*) has no early termination, so over a heavy report view it is the
+		//	most expensive pass. When there is no limit (export) every row is read anyway, so
+		//	the total equals the number of rows read; a separate COUNT would just re-evaluate
+		//	the whole view a second time. Only count separately when paginating.
+		reportInfo.withRecordCount(paginated
+			? CountUtil.countRecords(queryDefinition.getCompleteQueryCount(), format.getTableName(), queryDefinition.getParameters(), transactionName)
+			: 0);
 		DB.runResultSet(transactionName, queryDefinition.getCompleteQuery(), queryDefinition.getParameters(), resulset -> {
-			final List<PrintFormatItem> printFormatsList = format.getItems();
 			while (resulset.next()) {
-				printFormatsList.forEach(item -> {
-					Map<String, Cell> cells = new HashMap<String, Cell>();
-					queryDefinition.getQueryColumns()
-						.stream()
-						.filter(column -> {
-							return column.getColumnName().equals(item.getColumnName());
-						})
-						.forEach(column -> {
-							Cell cell = Optional.ofNullable(cells.get(column.getColumnName())).orElse(Cell.newInstance());
-							try {
-								if(column.isDisplayValue()) {
-									cell.withDisplayValue(resulset.getString(column.getColumnNameAlias()));
-								} else {
-									Object value = resulset.getObject(column.getColumnName());
-									cell.withValue(value);
-									//	Apply Default Mask
-									if(!Util.isEmpty(item.getMappingClassName())) {
-										IColumnMapping customMapping = ClassLoaderMapping.loadClass(item.getMappingClassName());
-										if(customMapping != null) {
-											customMapping.processValue(item, column, language, resulset, cell);
-										}
-									} else {
-										DefaultMapping.newInstance().processValue(item, column, language, resulset, cell);
-									}
-								}
-							} catch (Exception e) {
-								logger.warning(e.getLocalizedMessage());
-							}
-							cells.put(item.getColumnName(), cell);
-						})
-					;
-					reportInfo.addCell(item, cells.get(item.getColumnName()));
-				});
+				readRow(resulset, printFormatsList, queryDefinition, reportInfo, language);
 				if(format.getTableName().equals("T_Report")) {
 					reportInfo.addRow(resulset.getInt("LevelNo"), resulset.getInt("SeqNo"));
 				} else {
@@ -324,7 +325,83 @@ public class ReportBuilder {
 		}).onFailure(throwable -> {
 			throw new AdempiereException(throwable);
 		});
+		if (!paginated) {
+			//	Export read every row: the real total is what was materialized, which avoids
+			//	a second full pass over the view just to compute the record count.
+			reportInfo.withRecordCount(reportInfo.getRows().size());
+		}
 		return reportInfo.completeInfo();
+	}
+
+	/**
+	 * Build the cells for the current {@link ResultSet} row into the report's row
+	 * accumulator. Shared by the buffered and the streaming read paths.
+	 */
+	private void readRow(ResultSet resulset, List<PrintFormatItem> printFormatsList, QueryDefinition queryDefinition, ReportInfo reportInfo, Language language) {
+		printFormatsList.forEach(item -> {
+			Map<String, Cell> cells = new HashMap<String, Cell>();
+			queryDefinition.getQueryColumns()
+				.stream()
+				.filter(column -> {
+					return column.getColumnName().equals(item.getColumnName());
+				})
+				.forEach(column -> {
+					Cell cell = Optional.ofNullable(cells.get(column.getColumnName())).orElse(Cell.newInstance());
+					try {
+						if(column.isDisplayValue()) {
+							cell.withDisplayValue(resulset.getString(column.getColumnNameAlias()));
+						} else {
+							Object value = resulset.getObject(column.getColumnName());
+							cell.withValue(value);
+							//	Apply Default Mask
+							if(!Util.isEmpty(item.getMappingClassName())) {
+								IColumnMapping customMapping = ClassLoaderMapping.loadClass(item.getMappingClassName());
+								if(customMapping != null) {
+									customMapping.processValue(item, column, language, resulset, cell);
+								}
+							} else {
+								DefaultMapping.newInstance().processValue(item, column, language, resulset, cell);
+							}
+						}
+					} catch (Exception e) {
+						logger.warning(e.getLocalizedMessage());
+					}
+					cells.put(item.getColumnName(), cell);
+				})
+			;
+			reportInfo.addCell(item, cells.get(item.getColumnName()));
+		});
+	}
+
+	/**
+	 * Streaming export path: cursor-read the result set with a bounded JDBC fetch size and
+	 * write each row directly to the exporter, draining it from the accumulator so the full
+	 * result set is never held in memory at once.
+	 */
+	private void runStreamingExport(PrintFormat format, QueryDefinition queryDefinition, ReportInfo reportInfo, String transactionName, Language language) {
+		streamingExporter.beginStream(reportInfo);
+		final List<PrintFormatItem> printFormatsList = format.getItems();
+		CPreparedStatement pstmt = null;
+		ResultSet resultSet = null;
+		int count = 0;
+		try {
+			pstmt = DB.prepareStatement(queryDefinition.getCompleteQuery(), transactionName);
+			//	Cursor-based fetch so the JDBC driver streams instead of buffering every row.
+			pstmt.setFetchSize(1000);
+			DB.setParameters(pstmt, queryDefinition.getParameters());
+			resultSet = pstmt.executeQuery();
+			while (resultSet.next()) {
+				readRow(resultSet, printFormatsList, queryDefinition, reportInfo, language);
+				streamingExporter.writeStreamRow(reportInfo.drainRow());
+				count++;
+			}
+		} catch (SQLException e) {
+			throw new AdempiereException(e);
+		} finally {
+			DB.close(resultSet, pstmt);
+		}
+		reportInfo.withRecordCount(count);
+		reportInfo.withExportFileName(streamingExporter.finishStream());
 	}
 
 

--- a/src/main/java/org/spin/report_engine/service/Service.java
+++ b/src/main/java/org/spin/report_engine/service/Service.java
@@ -325,9 +325,11 @@ public class Service {
 			offset = (pageNumber - 1) * limit;
 		}
 
+		XlsxExporter exporter = XlsxExporter.newInstance();
 		ReportInfo reportInfo = reportBuilder
 			.withLimit(limit)
 			.withOffset(offset)
+			.withStreamingExporter(exporter)
 			.run()
 		;
 		RunExportResponse.Builder builder = RunExportResponse.newBuilder()
@@ -336,7 +338,12 @@ public class Service {
 			)
 		;
 
-		String fileName = XlsxExporter.newInstance().export(reportInfo);
+		//	When the report was streamed to disk the file is already written; otherwise export
+		//	the buffered result (summary / grouped / financial) with the same exporter.
+		String fileName = reportInfo.getExportFileName() != null
+			? reportInfo.getExportFileName()
+			: exporter.export(reportInfo)
+		;
 		if (!Util.isEmpty(fileName, true)) {
 			builder
 				.setFileName(


### PR DESCRIPTION
## Summary

Two performance fixes for view-based reports whose underlying query is expensive (e.g. views that evaluate scalar functions per row). On large, unfiltered runs these reports are slow and can exhaust the Java heap when exported.

- **Skip the redundant `COUNT(*)` pass** on export.
- **Stream large exports** instead of materializing the whole result set in memory.

## Background

For a view-based report the engine builds `SELECT … FROM <view>` and:

1. runs a separate `SELECT COUNT(*)` over the same view to get the total, then
2. reads every row into an in-memory `ArrayList` (`ReportInfo.rows`), which the exporter then iterates.

When the underlying view is expensive, the query is evaluated **twice**, and the full result set is held in memory — causing `Java heap space` on large exports.

## Changes

### Count only when paginating
`ReportBuilder.get()` always called `CountUtil.countRecords(...)` before fetching the data. `COUNT(*)` has no early termination, so over an expensive view it is effectively a second full evaluation.

- The `COUNT(*)` now runs **only when paginating** (`limit != NO_LIMIT`).
- On a full export the total is taken from the rows actually materialized/streamed, not from a separate query.

### Streaming export for flat reports
For a full (non-paginated) export of a **flat** report, the engine now streams instead of buffering:

- `ReportBuilder.runStreamingExport()` cursor-reads the `ResultSet` with `setFetchSize(1000)` (so the PostgreSQL driver streams rather than buffering the whole result set) and writes each row straight to the `SXSSFWorkbook`.
- New incremental exporter API in `XlsxExporter`: `beginStream()` / `writeStreamRow()` / `finishStream()`.
- `ReportInfo.drainRow()` materializes the current row and resets the accumulator **without retaining it**, so the full result set is never held in memory at once.
- `Service.getExportReport()` passes the exporter to the builder and uses the file already written when streaming happened, falling back to the buffered `export(reportInfo)` otherwise.

#### Gating (safe by design)
Streaming applies **only** when:
```
streamingExporter != null
  && !paginated            // full export
  && !isSummary()
  && tableName != "T_Report"   // not a financial report
  && groupItems.isEmpty()      // no group-by / subtotals
```
Summary, grouped and financial (`T_Report`) reports, and the paginated view path, keep the existing buffered behaviour (they need the full set in memory to build subtotals/hierarchy).

#### Supporting refactor (behaviour-preserving)
- `XlsxExporter`: extracted `writeHeader` / `writeDataRow` (shared by the buffered and streaming paths); `createSheet(boolean trackForAutoSize)` — auto-size column tracking is disabled while streaming (it would keep every row in memory).
- `ReportBuilder`: extracted `readRow(...)` (shared cell-building for the buffered and streaming loops).


## Files changed
| File | Change |
|---|---|
| `service/ReportBuilder.java` | count only when paginating; `runStreamingExport`, `readRow` extraction, gating, `withStreamingExporter` |
| `data/ReportInfo.java` | `drainRow()` + export filename carrier |
| `export/XlsxExporter.java` | incremental streaming API + `writeHeader`/`writeDataRow` extraction + `createSheet(boolean)` |
| `service/Service.java` | wire the streaming exporter; use the streamed file |


## Notes / caveats
- **Cosmetic:** streamed exports use a fixed column width (auto-size requires all rows in memory). Buffered exports keep auto-size.
- Streaming is **xlsx + flat-report only** by design.
- DB-side optimization of the underlying view (so the query itself is cheaper) is out of scope for this repository.