### PR TITLE
perf: Compute Row identity by value instead of serializing to a string

### DIFF
--- a/src/main/java/org/spin/report_engine/data/Row.java
+++ b/src/main/java/org/spin/report_engine/data/Row.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.compiere.util.Util;
@@ -133,13 +134,27 @@ public class Row {
 		return "level=" + level + ", Row [data=" + data + "]";
 	}
 	
+	// Identity is based on the row's level and cell values (not on a serialized
+	// toString). Row is used as a HashMap key in SummaryHandler, where the key only
+	// holds the group-by cells; basing equals/hashCode on (level, data) is equivalent
+	// to the previous toString comparison but avoids building a string on every
+	// lookup. Cell already implements equals/hashCode by value, so Map<Integer,Cell>
+	// compares and hashes correctly element by element.
 	@Override
 	public int hashCode() {
-	    return toString().hashCode();
+		return Objects.hash(level, data);
 	}
-	
+
 	@Override
 	public boolean equals(Object o) {
-	    return toString().equals(((Row)o).toString());
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof Row)) {
+			return false;
+		}
+		Row other = (Row) o;
+		return level == other.level && Objects.equals(data, other.data);
 	}
+
 }


### PR DESCRIPTION
## Summary

`Row.equals` and `Row.hashCode` were derived from `toString()`, which serialized the entire row (level + every cell) into a string on every call. Because `Row` is used as a `HashMap` key when accumulating group subtotals, each map lookup and insert rebuilt that full string, adding avoidable allocation and CPU cost that scales with the number of rows and groups.

This change derives identity directly from the row's `level` and its `data` cell map. `Cell` already implements `equals`/`hashCode` by value, so `Map<Integer, Cell>` compares and hashes correctly element by element without producing any intermediate strings.

## Changes

- Reimplement `Row.hashCode()` as `Objects.hash(level, data)`.
- Reimplement `Row.equals()` to compare `level` and `data` directly, with a proper `instanceof` guard.

## Behavior

- **Equivalent semantics.** The only place `Row` is used as a map key holds just the group-by cells with a constant level, so identity by `(level, data)` matches the previous `toString`-based comparison.
- **More robust.** `equals` now handles `null` and non-`Row` arguments instead of throwing `ClassCastException` / `NullPointerException` as the previous `((Row) o).toString()` did.
- **No change to report output**: same grouping, subtotals, and ordering.

## Testing

- `./gradlew compileJava` — BUILD SUCCESSFUL.
- Functional parity to validate at runtime: a multi-level grouped report and a financial (`T_Report`) report should produce identical values, subtotals, grouping, and ordering.