### PR TITLE
fix: Advance report pagination with page tokens

### DIFF
--- a/src/main/java/org/spin/report_engine/format/QueryDefinition.java
+++ b/src/main/java/org/spin/report_engine/format/QueryDefinition.java
@@ -266,43 +266,6 @@ public class QueryDefinition {
 			;
 		}
 
-		//	Add Limit records
-		StringBuffer limitClause = new StringBuffer();
-		if(this.limit != NO_LIMIT && DB.getDatabase().isPagingSupported()) {
-			if(this.limit == 0) {
-				withLimit(100, 0);
-			}
-
-			// limitClause
-				// TODO: Implement with use https://github.com/adempiere/adempiere/pull/4142
-				// .append(" LIMIT ")
-				// .append(this.limit)
-				// .append(" OFFSET ")
-				// .append(this.offset)
-				// .append(completeQueryCount)
-			;
-
-			// Apply pagination AFTER ordering using the database-specific paging
-			// syntax (PostgreSQL LIMIT/OFFSET, Oracle ROWNUM wrapper). Doing it at
-			// the database level guarantees the limit is applied to the already
-			// ordered result set, so paging is consistent with the native
-			// ReportEngine. addPagingSQL uses 1-based row numbers: the first row is
-			// offset + 1 and the last row is offset + limit.
-			// int start = this.offset + 1;
-			// int end = this.offset + this.limit;
-			// completeQuery = new StringBuffer(
-			// 	DB.getDatabase().addPagingSQL(baseQuery.toString(), start, end)
-			// );
-
-			if(!Util.isEmpty(this.getDynamicWhereClause(), true)) {
-				limitClause.insert(0, " AND ");
-			} else {
-				limitClause.insert(0, " WHERE ");
-			}
-			limitClause.append("ROWNUM <= ").append(this.limit);
-			limitClause.append(" AND ROWNUM >= ").append(this.offset);
-		}
-
 		// Add Group By
 		String groupByClause = "";
 		if(!Util.isEmpty(getGroupBy(), true)) {
@@ -316,9 +279,31 @@ public class QueryDefinition {
 			orderByClause = " ORDER BY " + getOrderBy();
 		}
 
+		// The count query is the full ordered query without paging.
 		String completeSql = query.toString() + groupByClause + orderByClause;
-		String completeSqlWithLimit = query.toString() + limitClause + groupByClause + orderByClause;
 		withCompleteQueryCount(completeSql);
+
+		// Apply pagination AFTER ordering using the database-specific paging syntax
+		// (PostgreSQL LIMIT/OFFSET, Oracle ROWNUM subquery wrapper). Doing it at the
+		// database level guarantees the limit is applied to the already ordered result
+		// set, so paging is consistent with the native ReportEngine and the database can
+		// optimize it (top-N) instead of materializing the whole view. addPagingSQL uses
+		// 1-based row numbers: the first row is offset + 1 and the last is offset + limit.
+		String completeSqlWithLimit = completeSql;
+		if(this.limit != NO_LIMIT && DB.getDatabase().isPagingSupported()) {
+			// limitClause
+				// TODO: Implement with use https://github.com/adempiere/adempiere/pull/4142
+				// .append(" LIMIT ")
+				// .append(this.limit)
+				// .append(" OFFSET ")
+				// .append(this.offset)
+				// .append(completeQueryCount)
+			// ;
+			int pageLimit = (this.limit == 0) ? 100 : this.limit;
+			int start = this.offset + 1;
+			int end = this.offset + pageLimit;
+			completeSqlWithLimit = DB.getDatabase().addPagingSQL(completeSql, start, end);
+		}
 		withCompleteQuery(completeSqlWithLimit);
 
 		return this;

--- a/src/main/java/org/spin/report_engine/format/QueryDefinition.java
+++ b/src/main/java/org/spin/report_engine/format/QueryDefinition.java
@@ -299,6 +299,15 @@ public class QueryDefinition {
 				// .append(this.offset)
 				// .append(completeQueryCount)
 			// ;
+
+			// if(!Util.isEmpty(this.getDynamicWhereClause(), true)) {
+			// 	limitClause.insert(0, " AND ");
+			// } else {
+			// 	limitClause.insert(0, " WHERE ");
+			// }
+			// limitClause.append("ROWNUM <= ").append(this.limit);
+			// limitClause.append(" AND ROWNUM >= ").append(this.offset);
+
 			int pageLimit = (this.limit == 0) ? 100 : this.limit;
 			int start = this.offset + 1;
 			int end = this.offset + pageLimit;

--- a/src/main/java/org/spin/report_engine/service/Service.java
+++ b/src/main/java/org/spin/report_engine/service/Service.java
@@ -430,7 +430,7 @@ public class Service {
 		//	Set page token
 		String nexPageToken = null;
 		if(LimitUtil.isValidNextPageToken((int) reportInfo.getRecordCount(), offset, limit)) {
-			nexPageToken = LimitUtil.getPagePrefix("") + String.valueOf(pageNumber + 1);
+			nexPageToken = LimitUtil.getPagePrefix(SessionManager.getSessionUuid()) + (pageNumber + 1);
 		}
 		builder.setNextPageToken(
 			TextManager.getValidString(nexPageToken)


### PR DESCRIPTION
## Summary

Report pagination did not advance: requesting the next page returned the first page again. The `next_page_token` was built with an empty session prefix, so it came out malformed (e.g. `-2`) and, when sent back, did not match the token format the reader expects — it was parsed as an invalid page number and silently fell back to page 1.

This PR fixes the token construction and, while there, replaces the hand-rolled `ROWNUM` pagination clause with the database-native paging API.

## Changes

### 1. Fix `next_page_token` (correctness)
- The token is now built with the same session prefix that the reader uses to parse it (`LimitUtil.getPagePrefix(SessionManager.getSessionUuid())`), instead of an empty string.
- Read side (`getPageNumber`) and write side now use the **same** session UUID, so the token round-trips to the correct page.
- Effect: "next page" now advances (page 2, 3, …) instead of reloading page 1.

### 2. Use native paging instead of `ROWNUM` (refactor, equivalent)
- Pagination is now applied with `DB.getDatabase().addPagingSQL(...)` over the already-ordered query, producing the canonical `... ORDER BY ... LIMIT n OFFSET m` form.
- Previously the query emitted an Oracle-style `ROWNUM <= limit AND ROWNUM >= offset` clause that relied on the PostgreSQL conversion layer to rewrite it. The result is functionally equivalent, but the explicit native form is clearer and does not depend on the regex-based converter to reorder the limit relative to `ORDER BY`.
- Edge cases preserved: default page size when `limit == 0`, no paging when `limit == NO_LIMIT`, and the `isPagingSupported()` guard.

## Affected endpoints
Both `GetReport` and `GetView` build their response through the shared `convertReport(...)`, so both are fixed. The export endpoint does not emit page tokens and is unaffected.