### PR TITLE
refactor: extract XlsxExporter magic numbers and make the flush window configurable

### DIFF
--- a/src/main/java/org/spin/report_engine/export/XlsxExporter.java
+++ b/src/main/java/org/spin/report_engine/export/XlsxExporter.java
@@ -70,14 +70,43 @@ import org.spin.util.support.IAppSupport;
  */
 public class XlsxExporter implements IReportEngineExporter {
 
+	/** Rows kept in memory before SXSSF flushes them to disk (streaming window). */
+	private static final int DEFAULT_FLUSH_ROWS = 100;
+
+	/** System property to tune the SXSSF flush window without a rebuild. */
+	private static final String FLUSH_ROWS_PROPERTY = "report.engine.xlsx.flushRows";
+
+	/** Fixed column width (1/256th of a character) applied when auto-sizing is unavailable. */
+	private static final int DEFAULT_COLUMN_WIDTH = 20 * 256;
+
 	public static XlsxExporter newInstance() {
 		return new XlsxExporter();
 	}
-	
+
 	private XlsxExporter() {
-		workBook = new SXSSFWorkbook(100);
+		workBook = new SXSSFWorkbook(getFlushRows());
 		language = Language.getLoginLanguage();
 		dataFormat = workBook.createDataFormat();
+	}
+
+	/**
+	 * Resolve the SXSSF flush window, allowing an override via the
+	 * {@value #FLUSH_ROWS_PROPERTY} system property; falls back to
+	 * {@link #DEFAULT_FLUSH_ROWS} when unset or invalid.
+	 */
+	private static int getFlushRows() {
+		String configured = System.getProperty(FLUSH_ROWS_PROPERTY);
+		if (!Util.isEmpty(configured)) {
+			try {
+				int value = Integer.parseInt(configured.trim());
+				if (value > 0) {
+					return value;
+				}
+			} catch (NumberFormatException e) {
+				// ignore and fall back to the default
+			}
+		}
+		return DEFAULT_FLUSH_ROWS;
 	}
 	
 	private SXSSFWorkbook workBook;
@@ -228,7 +257,7 @@ public class XlsxExporter implements IReportEngineExporter {
 	 */
 	public String finishStream() {
 		IntStream.range(0, streamColumns.size())
-			.forEach(columnNumber -> streamSheet.setColumnWidth(columnNumber, 20 * 256))
+			.forEach(columnNumber -> streamSheet.setColumnWidth(columnNumber, DEFAULT_COLUMN_WIDTH))
 		;
 		streamSheet.createFreezePane(0, 1);
 		return writeFile();


### PR DESCRIPTION

The XLSX exporter hardcoded two tuning values inline: the SXSSF flush window (`new SXSSFWorkbook(100)`) and the fixed column width used on the streaming path (`20 * 256`). Both are now named constants, and the flush window can be overridden at runtime via the `report.engine.xlsx.flushRows` system property without a rebuild — useful for tuning the memory/disk trade-off per environment. Invalid or unset values fall back to the previous default of 100.

The buffered export path is unchanged: it keeps auto-sizing columns, which is intentional behaviour rather than a hardcoded value.

Output is byte-identical with the default configuration; this is a cleanup with no functional change.