### PR TITLE
perf: skip redundant cell re-mapping for already-rendered rows in completeInfo

### DIFF
--- a/src/main/java/org/spin/report_engine/data/ReportInfo.java
+++ b/src/main/java/org/spin/report_engine/data/ReportInfo.java
@@ -341,17 +341,25 @@ public class ReportInfo {
 		summaryRows = new ArrayList<Row>();
 		completeRows.forEach(row -> {
 			Row newRow = Row.newInstance().withSourceRowDefinition(row);
+			//	Summary/group rows are assembled by SummaryHandler and never pass through
+			//	readRow, so their cells still need the display mapping applied here. Regular
+			//	rows were already mapped while reading the ResultSet (readRow uses the richer
+			//	overload, a superset of this one), so re-applying it would only recompute the
+			//	same display value; for those rows we just measure the rendered width.
+			boolean mapCells = newRow.isSummaryRow();
 			//	Items
 			printFormat.getItems().forEach(printFormatItem -> {
 				Cell cell = row.getCell(printFormatItem.getPrintFormatItemId());
-				//	Apply Default Mask
-				if(!Util.isEmpty(printFormatItem.getMappingClassName())) {
-					IColumnMapping customMapping = ClassLoaderMapping.loadClass(printFormatItem.getMappingClassName());
-					if(customMapping != null) {
-						customMapping.processValue(printFormatItem, language, cell);
+				//	Apply Default Mask (only for rows not already mapped by readRow)
+				if(mapCells) {
+					if(!Util.isEmpty(printFormatItem.getMappingClassName())) {
+						IColumnMapping customMapping = ClassLoaderMapping.loadClass(printFormatItem.getMappingClassName());
+						if(customMapping != null) {
+							customMapping.processValue(printFormatItem, language, cell);
+						}
+					} else {
+						DefaultMapping.newInstance().processValue(printFormatItem, language, cell);
 					}
-				} else {
-					DefaultMapping.newInstance().processValue(printFormatItem, language, cell);
 				}
 				int newLength = Optional.ofNullable(cell.getDisplayValue()).orElse("").length();
 				if(columnLength.containsKey(printFormatItem.getPrintFormatItemId())) {


### PR DESCRIPTION

`ReportInfo.completeInfo()` ran the column display-mapping over every row in the report, applying `processValue(...)` to each cell before measuring column widths and collecting summary rows.

For regular data rows this was redundant work: `readRow` already maps each cell while reading the ResultSet, using the richer `processValue(item, column, language, resultSet, cell)` overload — a superset of the one used here (which receives no column/ResultSet and can only recompute the same display value). Re-running it produced an identical result.

Only summary/group rows genuinely need mapping at this stage: they are assembled by `SummaryHandler` with a raw value and no display value, and never pass through `readRow`. This change applies the mapping only to those rows and, for the rest, just measures the already-rendered width. Column widths, summary-row collection and the final output are unchanged.